### PR TITLE
Response: Force array cast to not fail for nil values

### DIFF
--- a/app/helpers/wash_out_helper.rb
+++ b/app/helpers/wash_out_helper.rb
@@ -7,6 +7,7 @@ module WashOutHelper
         if !param.multiplied
           xml.tag! tag_name, param.value, "xsi:type" => param.namespaced_type
         else
+          param.value = [] unless param.value.is_a?(Array)
           param.value.each do |v|
             xml.tag! tag_name, v, "xsi:type" => param.namespaced_type
           end

--- a/lib/wash_out/dispatcher.rb
+++ b/lib/wash_out/dispatcher.rb
@@ -94,6 +94,7 @@ module WashOut
 
           # Inline array of complex structures
           elsif param.struct? && param.multiplied
+            data[param.name] = [] unless data[param.name].is_a?(Array)
             result_spec[i].map = data[param.name].map{|e| inject.call(e, param.map)}
 
           else

--- a/spec/wash_out_spec.rb
+++ b/spec/wash_out_spec.rb
@@ -134,6 +134,34 @@ describe WashOut do
     end
   end
 
+  context "optional arrays" do
+    it "should answer for simple structure" do
+      mock_controller do
+        soap_action "rocknroll",
+                    :args => nil, :return => { :my_value => [:integer] }
+        def rocknroll
+          render :soap => {}
+        end
+      end
+
+      client = savon_instance
+      client.request(:rocknroll).to_hash["rocknroll_response".to_sym].should be_nil
+    end
+
+    it "should answer for complex structure" do
+      mock_controller do
+        soap_action "rocknroll",
+                    :args => nil, :return => { :my_value => [{ :value => :integer}] }
+        def rocknroll
+          render :soap => {}
+        end
+      end
+
+      client = savon_instance
+      client.request(:rocknroll).to_hash["rocknroll_response".to_sym].should be_nil
+    end
+  end
+
   it "should answer to request with two parameter" do
     mock_controller do
       soap_action "funky", :args => { :a => :integer, :b => :string }, :return => :string


### PR DESCRIPTION
A response fails when optional array is not given. That's due to iterator call on nil values.

As fix, this PR forces an array cast - so `nil` values will be turned into `[]` and iterators works smoothly :-)
