### PR TITLE
Snakecase response keys (see #25)

### DIFF
--- a/app/helpers/wash_out_helper.rb
+++ b/app/helpers/wash_out_helper.rb
@@ -1,7 +1,7 @@
 module WashOutHelper
   def wsdl_data(xml, params)
     params.each do |param|
-      tag_name = "tns:#{param.name}"
+      tag_name = param.namespaced_name
 
       if !param.struct?
         if !param.multiplied

--- a/lib/wash_out/dispatcher.rb
+++ b/lib/wash_out/dispatcher.rb
@@ -87,18 +87,19 @@ module WashOut
 
         map.each_with_index do |param, i|
           result_spec[i] = param.flat_copy
+          data_value     = data[param.name] || data[param.name.snakecase]
 
           # Inline complex structure
           if param.struct? && !param.multiplied
-            result_spec[i].map = inject.call(data[param.name], param.map)
+            result_spec[i].map = inject.call(data_value, param.map)
 
           # Inline array of complex structures
           elsif param.struct? && param.multiplied
-            data[param.name] = [] unless data[param.name].is_a?(Array)
-            result_spec[i].map = data[param.name].map{|e| inject.call(e, param.map)}
+            data_value = [] unless data_value.is_a?(Array)
+            result_spec[i].map = data_value.map{|e| inject.call(e, param.map)}
 
           else
-            result_spec[i].value = data[param.name]
+            result_spec[i].value = data_value
 
           end
         end

--- a/lib/wash_out/param.rb
+++ b/lib/wash_out/param.rb
@@ -69,9 +69,13 @@ module WashOut
       type == 'struct'
     end
 
+    def namespaced_name
+      "tns:#{name}"
+    end
+
     # Returns a WSDL namespaced identifier for this type.
     def namespaced_type
-      struct? ? "tns:#{name}" : "xsd:#{type}"
+      struct? ? namespaced_name : "xsd:#{type}"
     end
 
     # Parses a +definition+. The format of the definition is best described

--- a/spec/wash_out_spec.rb
+++ b/spec/wash_out_spec.rb
@@ -469,4 +469,16 @@ describe WashOut do
       ]
     }
   end
+
+  it "should autoconvert snakecase if answer expects camelcase" do
+    mock_controller do
+      soap_action "rocknroll",
+                  :args => nil, :return => { :MyValue => :integer }
+      def rocknroll
+        render :soap => { :my_value => 42 }
+      end
+    end
+
+    client.request(:rocknroll).to_xml.should include('<tns:MyValue xsi:type="xsd:integer">42</tns:MyValue>')
+  end
 end


### PR DESCRIPTION
This is a first (yet bit rough) proposal how to approach #25.

 This PR adds an additional check on snakecased keys to the response data<->spec resolve process. This way one can spec a camelcased response, but still pass in snakecased keys. (see spec for an example)

By now this fallback is applied in any case, it may makes sense to bind it to the `snakecase` (or different) option. let's discuss...
