### PR TITLE
Don't fail when missing SOAPACTION

### DIFF
--- a/lib/wash_out/router.rb
+++ b/lib/wash_out/router.rb
@@ -9,14 +9,14 @@ module WashOut
     def call(env)
       controller = @controller_name.constantize
 
-      soap_action = env['HTTP_SOAPACTION']
+      if soap_action = env['HTTP_SOAPACTION']
+        # RUBY18 1.8 does not have force_encoding.
+        soap_action.force_encoding('UTF-8') if soap_action.respond_to? :force_encoding
 
-      # RUBY18 1.8 does not have force_encoding.
-      soap_action.force_encoding('UTF-8') if soap_action.respond_to? :force_encoding
+        soap_action.gsub!(/^\"(.*)\"$/, '\1')
 
-      soap_action.gsub!(/^\"(.*)\"$/, '\1')
-
-      env['wash_out.soap_action'] = soap_action
+        env['wash_out.soap_action'] = soap_action
+      end
 
       action_spec = controller.soap_actions[soap_action]
       if action_spec


### PR DESCRIPTION
Another tiny but significant PR. As you know I had problems with empty SOAPACTION. Which means, the header variable was set, but an empty string. I fixed that with a rack middleware, sth like: 

``` ruby
    def call(env)
      env["HTTP_SOAPACTION"] = "check"
      @app.call(env)
    end
```

this worked, but of course added to _any_ request the soap action value. Better solution is to update the value only if is a empty string:

``` ruby
    def call(env)
      if env.has_key?('HTTP_SOAPACTION') &&  env["HTTP_SOAPACTION"].empty?
        env["HTTP_SOAPACTION"] = "check"
      end
      @app.call(env)
    end
```

But this lead to another **problem**:
[wash_out always expects](https://github.com/rngtng/wash_out/blob/master/lib/wash_out/router.rb#L12) an action to be set. If not, `soap_action` is `nil` which will break all following string (e.g. `force_encoding`, `gsub`etc.)

By adding a condition, we prevent processing the `nil` value and wash_out will at least end up in `_invalid_action` and return a proper SOAP error.
