### PR TITLE
ruby-1.8.7 compatibility patch

### DIFF
--- a/lib/wash_out/dispatcher.rb
+++ b/lib/wash_out/dispatcher.rb
@@ -10,7 +10,7 @@ module WashOut
     class SOAPError < Exception; end
 
     def deep_select(hash, result=[], &blk)
-      result += hash.select(&blk).values
+      result += Hash[hash.select(&blk)].values
 
       hash.each do |key, value|
         result = deep_select(value, result, &blk) if value.is_a? Hash


### PR DESCRIPTION
Hash#select works differently in ruby 1.9,
this seems a good workaround

The idea is from:
http://bibwild.wordpress.com/2012/04/12/ruby-hash-select-1-8-7-and-1-9-3-simultaneously-compatible/
