### PR TITLE
ruby 1.8 compatible lambda syntax

### DIFF
--- a/lib/wash_out/param.rb
+++ b/lib/wash_out/param.rb
@@ -63,7 +63,7 @@ module WashOut
           when 'string';    :to_s
           when 'integer';   :to_i
           when 'double';    :to_f
-          when 'boolean';   ->(v){ v == 'true' }
+          when 'boolean';   lambda { |v| v == 'true' }
           when 'date';      :to_date
           when 'datetime';  :to_datetime
           when 'time';      :to_time


### PR DESCRIPTION
I think we can maintain compatibility on the master branch,
at least until required changes are tiny.
