### PR TITLE
Remove format matcher from routes.

### DIFF
--- a/lib/wash_out.rb
+++ b/lib/wash_out.rb
@@ -14,8 +14,8 @@ module ActionDispatch::Routing
       options.reverse_merge!(@scope) if @scope
       controller_class_name = [options[:module], controller_name].compact.join("/")
 
-      match "#{controller_name}/wsdl" => "#{controller_name}#_generate_wsdl", :via => :get
-      match "#{controller_name}/action" => WashOut::Router.new(controller_class_name), :defaults => { :action => '_action' }
+      match "#{controller_name}/wsdl"   => "#{controller_name}#_generate_wsdl", :via => :get, :format => false
+      match "#{controller_name}/action" => WashOut::Router.new(controller_class_name), :defaults => { :action => '_action' }, :format => false
     end
   end
 end


### PR DESCRIPTION
As there is no need to have the routes defined for multiple format types, this changes makes the setup lighter and less complex.
