### PR TITLE
Generation of service location adresse doesn't work properly when running multiple SOAP services.

### DIFF
--- a/app/views/wash_with_soap/wsdl.builder
+++ b/app/views/wash_with_soap/wsdl.builder
@@ -49,7 +49,7 @@ xml.definitions 'xmlns' => 'http://schemas.xmlsoap.org/wsdl/',
 
   xml.service :name => "service" do
     xml.port :name => "#{@name}_port", :binding => "tns:#{@name}_binding" do
-      xml.tag! "soap:address", :location => url_for(:action => '_action', :only_path => false)
+      xml.tag! "soap:address", :location => eval("#{@name}_action_url")
     end
   end
 


### PR DESCRIPTION
When running multiple SOAP services the url_for method doen't generate a proper url for the location address in the WSDL file of the invoked services. It only generate's a matching url for the first service.

If you have defined two services e.g.

``` ruby
wash_out :a
wash_out :b
```

the generated location url for the first service will be 

```
<port name="a_port" binding="tns:a_binding">
  <soap:address location="http://localhost:3000/a/action?controller=a"/>
</port>
```

and for the second

```
<port name="b_port" binding="tns:b_binding">
  <soap:address location="http://localhost:3000/a/action?controller=b"/>
</port>
```

I changed the behaviour to generate following URLs

```
http://localhost:3000/a/action
http://localhost:3000/b/action
```
