### PR TITLE
Camelize the response message also in WSDL.

### DIFF
--- a/app/views/wash_with_soap/wsdl.builder
+++ b/app/views/wash_with_soap/wsdl.builder
@@ -23,7 +23,7 @@ xml.definitions 'xmlns' => 'http://schemas.xmlsoap.org/wsdl/',
     @map.keys.each do |operation|
       xml.operation :name => operation do
         xml.input :message => "tns:#{operation}"
-        xml.output :message => "tns:#{operation}_response"
+        xml.output :message => "tns:#{operation}#{WashOut::Engine.camelize_wsdl ? 'Response' : '_response'}"
       end
     end
   end
@@ -59,7 +59,7 @@ xml.definitions 'xmlns' => 'http://schemas.xmlsoap.org/wsdl/',
         xml.part wsdl_occurence(p, true, :name => p.name, :type => p.namespaced_type)
       end
     end
-    xml.message :name => "#{operation}_response" do
+    xml.message :name => "#{operation}#{WashOut::Engine.camelize_wsdl ? 'Response' : '_response'}" do
       formats[:out].each do |p|
         xml.part wsdl_occurence(p, true, :name => p.name, :type => p.namespaced_type)
       end


### PR DESCRIPTION
The WSDL was broken because message names were not camelized as they are in [responses](https://github.com/roundlake/wash_out/blob/master/app/views/wash_with_soap/response.builder#L7).
