### PR TITLE
Improve error messages for programmer mistakes.

### DIFF
--- a/lib/wash_out/dispatcher.rb
+++ b/lib/wash_out/dispatcher.rb
@@ -8,6 +8,7 @@ module WashOut
     # A SOAPError exception can be raised to return a correct SOAP error
     # response.
     class SOAPError < Exception; end
+    class ProgrammerError < Exception; end
 
     # This filter parses the SOAP request and puts it into +params+ array.
     def _parse_soap_parameters
@@ -122,12 +123,26 @@ module WashOut
 
           # Inline array of complex structures
           elsif param.struct? && param.multiplied
-            data ||= {} #fallback in case no data is given
+            if data.nil?
+              data = {} # when no data is given
+            elsif data.is_a?(Array)
+              raise ProgrammerError,
+                "SOAP response used #{data.inspect} (which is an Array), " +
+                "in the context where a Hash with key of '#{param.raw_name}' " +
+                "was expected."
+            end
             data[param.raw_name] = [] unless data[param.raw_name].is_a?(Array)
             result_spec[i].map = data[param.raw_name].map{|e| inject.call(e, param.map)}
 
           else
-            result_spec[i].value = data[param.raw_name]
+            val = data[param.raw_name]
+            if param.multiplied and val and not val.is_a?(Array)
+              raise ProgrammerError,
+                "SOAP response tried to use '#{val.inspect}' " +
+                "(which is of type #{val.class}), as the value for " +
+                "'#{param.raw_name}' (which expects an Array)."
+            end
+            result_spec[i].value = val
           end
         end
 


### PR DESCRIPTION
1. For when an Array is expected but you pass a Hash

Before, its error message came from implicit conversion of the hash key
into an Integer by its use as an index on the Array.

This is to work with the type of XML that is fairly common, e.g.:

``` xml
<stallions>
  <stallion>a</stallion>
  <stallion>b</stallion>
  <stallion>c</stallion>
</stallion>
```

But it is easy to mess up the format in the render :soap.
1. For when an Array is expected but you pass a String

This was silently discarding the value. Now it raises an exception.
