### PR TITLE
Properly emit soap:Fault's on XML input error

### DIFF
--- a/lib/wash_out/dispatcher.rb
+++ b/lib/wash_out/dispatcher.rb
@@ -40,6 +40,8 @@ module WashOut
       Nori.strip_namespaces = strip
       Nori.advanced_typecasting = typecast
       Nori.convert_tags_to convert
+    rescue REXML::ParseException => e
+      render_soap_error e
     end
 
     def _authenticate_wsse


### PR DESCRIPTION
Previously, if the client sent junk XML, the exception would bubble up
to the application with no (obvious) way of trapping it.

This patch converts any XML parse errors into a basic render_soap_error.

Take note that the mocking in the spec is a bit convoluted. At the
moment, the dev version of savon is 0.9.9, which lacks the fuller
"hooks" interface that has come about since then.

Our first idea was to upgrade the dev dep to savon 1.2.0, but it causes
several tests to fail (and we didn't debug why).
