### PR TITLE
Changes to wash_out gem

### DIFF
--- a/lib/wash_out/dispatcher.rb
+++ b/lib/wash_out/dispatcher.rb
@@ -74,7 +74,6 @@ module WashOut
 
       action_spec[:in].each do |param|
         key = param.raw_name.to_sym
-
         if xml_data.has_key? key
           @_params[param.raw_name] = param.load(xml_data, key)
         end
@@ -157,7 +156,7 @@ module WashOut
     # Rails do not support sequental rescue_from handling, that is, rescuing an
     # exception from a rescue_from handler. Hence this function is a public API.
     def render_soap_error(message)
-      render :template => 'wash_with_soap/error', :status => 500,
+      render :template => 'wash_with_soap/error', :status => 422,
              :layout => false,
              :locals => { :error_message => message },
              :content_type => 'text/xml'

--- a/lib/wash_out/param.rb
+++ b/lib/wash_out/param.rb
@@ -70,14 +70,18 @@ module WashOut
           else raise RuntimeError, "Invalid WashOut simple type: #{type}"
         end
 
-        if operation.nil? || data.nil?
-          data
-        elsif @multiplied
-          data.map{|x| x.send(operation)}
-        elsif operation.is_a? Symbol
-          data.send(operation)
-        else
-          operation.call(data)
+        begin
+          if operation.nil? || data.nil?
+            data
+          elsif @multiplied
+            data.map{|x| x.send(operation)}
+          elsif operation.is_a? Symbol
+            data.send(operation)
+          else
+            operation.call(data)
+          end
+        rescue
+          raise WashOut::Dispatcher::SOAPError, "Invalid SOAP parameter '#{key}' format"
         end
       end
     end

--- a/spec/lib/wash_out_spec.rb
+++ b/spec/lib/wash_out_spec.rb
@@ -391,6 +391,18 @@ describe WashOut do
         }.should raise_exception(Savon::SOAPFault)
       end
 
+      it "raise for date in incorrect format" do
+        mock_controller do
+          soap_action "date", :args => :date, :return => :nil
+          def date
+            render :soap => nil
+          end
+        end
+        lambda {
+          savon(:date, :value  => 'incorrect format')
+        }.should raise_exception(Savon::SOAPFault)
+      end
+
       it "raise to report SOAP errors" do
         mock_controller do
           soap_action "error", :args => { :need_error => :boolean }, :return => nil


### PR DESCRIPTION
I made the following changes to the wash_out gem:
- the wash_out gem used to crash when converting a malformed string to date/timestamp object. Right now, when there is an exception caught during mapping soap parameters to Ruby's objects and a proper error message is sent.
- Changed http error code from 500 to 422
