### PR TITLE
Ruby 1.8.7 compatibility for the dispatcher.

### DIFF
--- a/lib/wash_out/dispatcher.rb
+++ b/lib/wash_out/dispatcher.rb
@@ -15,11 +15,8 @@ module WashOut
       parser = Nori.new(
         :strip_namespaces => true,
         :advanced_typecasting => true,
-        :convert_tags_to => (
-          WashOut::Engine.snakecase_input ? lambda { |tag| tag.snakecase.to_sym }
-                                          : lambda { |tag| tag.to_sym }
-        )
-      )
+        :convert_tags_to => ( WashOut::Engine.snakecase_input ? lambda { |tag| tag.snakecase.to_sym } \
+                                : lambda { |tag| tag.to_sym } ))
 
       @_params = parser.parse(request.body.read)
       references = WashOut::Dispatcher.deep_select(@_params){|k,v| v.is_a?(Hash) && v.has_key?(:@id)}


### PR DESCRIPTION
I know 1.8.7 is almost EOL, but until we can get all our applications running with 1.9.x, this is one change I needed to make to run the gem with 1.8.7.
