### PR TITLE
added support for soap requests like namepace#action

### DIFF
--- a/lib/wash_out/router.rb
+++ b/lib/wash_out/router.rb
@@ -15,7 +15,7 @@ module WashOut
 
         if WashOut::Engine.namespace
           namespace = Regexp.escape WashOut::Engine.namespace.to_s
-          soap_action.gsub!(/^\"(#{namespace}\/?)?(.*)\"$/, '\2')
+          soap_action.gsub!(/^\"(#{namespace}(\/|#)?)?(.*)\"$/, '\3')
         else
           soap_action = soap_action[1...-1]
         end


### PR DESCRIPTION
Some SOAP clients (such as the one implemented in www.sonos.com's boxes) build actions like namespace#action instead of namespace/action.

The regexp used in lib/wash_out/router.rb to remove the namespace from the action missed that case, therefore, these requests were always failing.
