### PR TITLE
Update README to reflect new Savon argument handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ gem like Savon, a request can be done using this path:
 ```ruby
 require 'savon'
 
-client = Savon::Client.new("http://localhost:3000/rumbas/wsdl")
+client = Savon::Client.new(wsdl: "http://localhost:3000/rumbas/wsdl")
 
 client.wsdl.soap_actions # => [:integer_to_string, :concat, :add_circle]
 


### PR DESCRIPTION
When instantiating Savon it now takes a hash instead of a string
