### PR TITLE
Demodulize names of Reusable types if they are located in a module

### DIFF
--- a/lib/wash_out/type.rb
+++ b/lib/wash_out/type.rb
@@ -14,7 +14,7 @@ module WashOut
     end
 
     def self.wash_out_param_name
-      @param_type_name ||= name.underscore
+      @param_type_name ||= name.gsub( '/', '.').underscore
 
       if WashOut::Engine.camelize_wsdl.to_s == 'lower'
         @param_type_name = @param_type_name.camelize(:lower)


### PR DESCRIPTION
Added a demodulize to the wash_out_param_name function for types, to avoid a complexType being generated with a "module/class_name" structure.

I'm not sure if everyone considers this desired functionality, but I intend to use quite a few reusable types, and want to group them in a separate module. This fix insures the complexType name generated won't include the module name (which as far as I can see is not supported in WSDL's anyway).

Example:

``` ruby
soap_action :test_action,
            args: TestModule::Request,
            return: TestModule::Response
```

will currently generate the following complexType name in the WSDL:

``` xml
<xsd:complexType name="test_module/request">
```

Which isn't supported in a WSDL.

The fix changes it tot this:

``` xml
<xsd:complexType name="request">
```
