### PR TITLE
Per SOAP Service configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ In your Gemfile, add this line:
 
     gem 'wash_out'
 
+## Upgrading from version < 0.8.5
+
+Replace `include WashOut::Soap` with `soap_service` at the controller level.
+
 ## Usage
 
 A SOAP endpoint in WashOut is simply a Rails controller which includes the module WashOut::SOAP. Each SOAP
@@ -34,7 +38,7 @@ demonstrated.
 ```ruby
 # app/controllers/rumbas_controller.rb
 class RumbasController < ApplicationController
-  include WashOut::SOAP
+  soap_service namespace: 'urn:WashOut'
 
   # Simple case
   soap_action "integer_to_string",
@@ -139,7 +143,8 @@ inside your interface declarations.
 
 ## Configuration
 
-Use `config.wash_out...` inside your environment configuration to setup WashOut.
+Use `config.wash_out...` inside your environment configuration to setup WashOut globally.
+To override the values on a specific controller just add an override as part of the arguments to the `soap_service` method.
 
 Available properties are:
 
@@ -149,7 +154,7 @@ Available properties are:
 * **namespace**: SOAP namespace to use. Default is `urn:WashOut`.
 * **snakecase**: *(DEPRECATED SINCE 0.4.0)* Determines if WashOut should modify parameters keys to snakecase. Default is `false`.
 * **snakecase_input**: Determines if WashOut should modify parameters keys to snakecase. Default is `false`.
-* **camelize_wsdl**: Determines if WashOut should camelize types within WSDL and responses. Default is `false`.
+* **camelize_wsdl**: Determines if WashOut should camelize types within WSDL and responses. Supports `true` for CamelCase and `:lower` for camelCase. Default is `false`.
 
 ### Camelization
 
@@ -163,6 +168,9 @@ soap_action "foo" # this will be passed as is
 ## Maintainers
 
 * Boris Staal, [@inossidabile](http://staal.io)
+
+## Contributors
+* Mikael Henriksson, [@mhenrixon](http://twitter.com/mhenrixon)
 
 ## License
 

--- a/app/helpers/wash_out_helper.rb
+++ b/app/helpers/wash_out_helper.rb
@@ -1,7 +1,7 @@
 module WashOutHelper
 
   def wsdl_data_options(param)
-    case WashOut::Engine.style
+    case controller.soap_config.wsdl_style
     when 'rpc'
       { :"xsi:type" => param.namespaced_type }
     when 'document'

--- a/app/views/wash_with_soap/document/response.builder
+++ b/app/views/wash_with_soap/document/response.builder
@@ -3,7 +3,7 @@ xml.tag! "soap:Envelope", "xmlns:soap" => 'http://schemas.xmlsoap.org/soap/envel
                           "xmlns:xsd" => 'http://www.w3.org/2001/XMLSchema',
                           "xmlns:tns" => @namespace do
   xml.tag! "soap:Body" do
-    key = "tns:#{@operation}#{WashOut::Engine.camelize_wsdl ? 'Response' : '_response'}"
+    key = "tns:#{@operation}#{controller.soap_config.camelize_wsdl ? 'Response' : '_response'}"
 
     xml.tag! @action_spec[:response_tag] do
       wsdl_data xml, result

--- a/app/views/wash_with_soap/document/wsdl.builder
+++ b/app/views/wash_with_soap/document/wsdl.builder
@@ -23,7 +23,7 @@ xml.definitions 'xmlns' => 'http://schemas.xmlsoap.org/wsdl/',
     @map.keys.each do |operation|
       xml.operation :name => operation do
         xml.input :message => "tns:#{operation}"
-        xml.output :message => "tns:#{operation}#{WashOut::Engine.camelize_wsdl ? 'Response' : '_response'}"
+        xml.output :message => "tns:#{operation}#{controller.soap_config.camelize_wsdl ? 'Response' : '_response'}"
       end
     end
   end
@@ -59,7 +59,7 @@ xml.definitions 'xmlns' => 'http://schemas.xmlsoap.org/wsdl/',
         xml.part wsdl_occurence(p, false, :name => p.name, :type => p.namespaced_type)
       end
     end
-    xml.message :name => "#{operation}#{WashOut::Engine.camelize_wsdl ? 'Response' : '_response'}" do
+    xml.message :name => "#{operation}#{controller.soap_config.camelize_wsdl ? 'Response' : '_response'}" do
       formats[:out].each do |p|
         xml.part wsdl_occurence(p, false, :name => p.name, :type => p.namespaced_type)
       end

--- a/app/views/wash_with_soap/rpc/response.builder
+++ b/app/views/wash_with_soap/rpc/response.builder
@@ -4,7 +4,7 @@ xml.tag! "soap:Envelope", "xmlns:soap" => 'http://schemas.xmlsoap.org/soap/envel
                           "xmlns:xsi" => 'http://www.w3.org/2001/XMLSchema-instance',
                           "xmlns:tns" => @namespace do
   xml.tag! "soap:Body" do
-    key = "tns:#{@operation}#{WashOut::Engine.camelize_wsdl ? 'Response' : '_response'}"
+    key = "tns:#{@operation}#{controller.soap_config.camelize_wsdl ? 'Response' : '_response'}"
 
     xml.tag! @action_spec[:response_tag] do
       wsdl_data xml, result

--- a/app/views/wash_with_soap/rpc/wsdl.builder
+++ b/app/views/wash_with_soap/rpc/wsdl.builder
@@ -23,7 +23,7 @@ xml.definitions 'xmlns' => 'http://schemas.xmlsoap.org/wsdl/',
     @map.keys.each do |operation|
       xml.operation :name => operation do
         xml.input :message => "tns:#{operation}"
-        xml.output :message => "tns:#{operation}#{WashOut::Engine.camelize_wsdl ? 'Response' : '_response'}"
+        xml.output :message => "tns:#{operation}#{controller.soap_config.camelize_wsdl ? 'Response' : '_response'}"
       end
     end
   end
@@ -59,7 +59,7 @@ xml.definitions 'xmlns' => 'http://schemas.xmlsoap.org/wsdl/',
         xml.part wsdl_occurence(p, true, :name => p.name, :type => p.namespaced_type)
       end
     end
-    xml.message :name => "#{operation}#{WashOut::Engine.camelize_wsdl ? 'Response' : '_response'}" do
+    xml.message :name => "#{operation}#{controller.soap_config.camelize_wsdl ? 'Response' : '_response'}" do
       formats[:out].each do |p|
         xml.part wsdl_occurence(p, true, :name => p.name, :type => p.namespaced_type)
       end

--- a/lib/wash_out.rb
+++ b/lib/wash_out.rb
@@ -1,3 +1,6 @@
+require 'wash_out/configurable'
+require 'wash_out/soap_config'
+require 'wash_out/soap'
 require 'wash_out/engine'
 require 'wash_out/param'
 require 'wash_out/dispatcher'
@@ -28,9 +31,17 @@ ActionController::Renderers.add :soap do |what, options|
   _render_soap(what, options)
 end
 
-module ActionView
-  class Base
-    cattr_accessor :washout_namespace
-    @@washout_namespace = false
+ActionController::Base.class_eval do
+
+  # Define a SOAP service. The function has no required +options+:
+  # but allow any of :parser, :namespace, :wsdl_style, :snakecase_input,
+  # :camelize_wsdl, :wsse_username, :wsse_password and :catch_xml_errors.
+  #
+  # Any of the the params provided allows for overriding the defaults
+  # (like supporting multiple namespaces instead of application wide such)
+  #
+  def self.soap_service(options={})
+    include WashOut::SOAP
+    self.soap_config = options
   end
 end

--- a/lib/wash_out/configurable.rb
+++ b/lib/wash_out/configurable.rb
@@ -1,0 +1,41 @@
+module WashOut
+  module Configurable
+    extend ActiveSupport::Concern
+
+    included do
+      cattr_reader :soap_config
+      class_variable_set :@@soap_config, WashOut::SoapConfig.new({})
+    end
+
+    module ClassMethods
+
+      def soap_config=(obj)
+
+        unless obj.is_a?(Hash)
+          raise "Value needs to be a Hash."
+        end
+
+        if class_variable_defined?(:@@soap_config)
+          class_variable_get(:@@soap_config).configure obj
+        else
+          class_variable_set :@@soap_config, WashOut::SoapConfig.new(obj)
+        end
+      end
+    end
+
+    def soap_config=(obj)
+
+      unless obj.is_a?(Hash)
+        raise "Value needs to be a Hash."
+      end
+
+      class_eval do
+        if class_variable_defined?(:@@soap_config)
+          class_variable_get(:@@soap_config).configure obj
+        else
+          class_variable_set :@@soap_config, WashOut::SoapConfig.new(obj)
+        end
+      end
+    end
+  end
+end

--- a/lib/wash_out/engine.rb
+++ b/lib/wash_out/engine.rb
@@ -1,49 +1,9 @@
+
 module WashOut
   class Engine < ::Rails::Engine
-    class << self
-      attr_accessor :parser
-      attr_accessor :namespace
-      attr_accessor :style
-      attr_accessor :snakecase, :camelize_output
-      attr_accessor :snakecase_input, :camelize_wsdl
-      attr_accessor :wsse_username, :wsse_password
-      attr_accessor :catch_xml_errors
-    end
-
-    self.parser    = :rexml
-
-    self.namespace = 'urn:WashOut'
-    self.style     = 'rpc'
-    self.snakecase = nil
-
-    self.snakecase_input = false
-    self.camelize_wsdl   = false
-
-    self.wsse_username = nil
-    self.wsse_password = nil
-
     config.wash_out = ActiveSupport::OrderedOptions.new
-
     initializer "wash_out.configuration" do |app|
-      app.config.wash_out.each do |key, value|
-        self.class.send "#{key}=", value
-      end
-
-      app.config.wash_out.catch_xml_errors ||= false
-
-      unless self.class.snakecase.nil?
-        raise "Usage of wash_out.snakecase is deprecated. You should use wash_out.snakecase_input and wash_out.camelize_wsdl"
-      end
-
-      unless self.class.camelize_output.nil?
-        raise "Usage of wash_out.camelize_output is deprecated. You should use wash_out.camelize_wsdl option instead"
-      end
-
-      unless ['rpc','document'].include? self.class.style
-        raise "Invalid binding.  Style must be one of #{['rpc','document'].join(',')}"
-      end
-
-      if self.class.catch_xml_errors
+      if app.config.wash_out[:catch_xml_errors]
         app.config.middleware.insert_after 'ActionDispatch::ShowExceptions', WashOut::Middleware
       end
     end

--- a/lib/wash_out/router.rb
+++ b/lib/wash_out/router.rb
@@ -13,8 +13,8 @@ module WashOut
         # RUBY18 1.8 does not have force_encoding.
         soap_action.force_encoding('UTF-8') if soap_action.respond_to? :force_encoding
 
-        if WashOut::Engine.namespace
-          namespace = Regexp.escape WashOut::Engine.namespace.to_s
+        if controller.soap_config.namespace
+          namespace = Regexp.escape controller.soap_config.namespace.to_s
           soap_action.gsub!(/^\"(#{namespace}(\/|#)?)?(.*)\"$/, '\3')
         else
           soap_action = soap_action[1...-1]

--- a/lib/wash_out/soap.rb
+++ b/lib/wash_out/soap.rb
@@ -15,21 +15,22 @@ module WashOut
       # which are not valid Ruby function names.
       def soap_action(action, options={})
         if action.is_a?(Symbol)
-          if WashOut::Engine.camelize_wsdl.to_s == 'lower'
+          if soap_config.camelize_wsdl.to_s == 'lower'
             options[:to] ||= action.to_s
             action         = action.to_s.camelize(:lower)
-          elsif WashOut::Engine.camelize_wsdl
+          elsif soap_config.camelize_wsdl
             options[:to] ||= action.to_s
             action         = action.to_s.camelize
           end
+
         end
 
-        default_response_tag = WashOut::Engine.camelize_wsdl ? 'Response' : '_response'
+        default_response_tag = soap_config.camelize_wsdl ? 'Response' : '_response'
         default_response_tag = "tns:#{action}#{default_response_tag}"
 
         self.soap_actions[action] = {
-          :in           => WashOut::Param.parse_def(options[:args]),
-          :out          => WashOut::Param.parse_def(options[:return]),
+          :in           => WashOut::Param.parse_def(soap_config, options[:args]),
+          :out          => WashOut::Param.parse_def(soap_config, options[:return]),
           :to           => options[:to] || action,
           :response_tag => options[:response_tag] || default_response_tag
         }
@@ -37,6 +38,7 @@ module WashOut
     end
 
     included do
+      include WashOut::Configurable
       include WashOut::Dispatcher
       self.soap_actions = {}
     end

--- a/lib/wash_out/soap_config.rb
+++ b/lib/wash_out/soap_config.rb
@@ -1,0 +1,91 @@
+module WashOut
+  require 'forwardable'
+  # Configuration options for {Client}, defaulting to values
+  # in {Default}
+  class SoapConfig
+    extend Forwardable
+    DEFAULT_CONFIG = {
+      parser: :rexml,
+      namespace: 'urn:WashOut',
+      wsdl_style: 'rpc',
+      snakecase_input: false,
+      camelize_wsdl: false,
+      catch_xml_errors: false,
+      wsse_username: nil,
+      wsse_password: nil,
+    }
+
+    attr_reader :config
+    def_delegators :@config, :[], :[]=, :sort
+
+
+    # The keys allowed
+    def self.keys
+      @keys ||= config.keys
+    end
+
+    def self.config
+      DEFAULT_CONFIG
+    end
+
+    def self.soap_accessor(*syms)
+      syms.each do |sym|
+
+        unless sym =~ /^[_A-Za-z]\w*$/
+          raise NameError.new("invalid class attribute name: #{sym}")
+        end
+        class_eval(<<-EOS, __FILE__, __LINE__ + 1)
+          unless defined? @#{sym}
+            @#{sym} = nil
+          end
+
+          def #{sym}
+            @#{sym}
+          end
+
+          def #{sym}=(obj)
+            @#{sym} = obj
+          end
+        EOS
+      end
+    end
+
+    soap_accessor(*WashOut::SoapConfig.keys)
+
+    def initialize(options = {})
+      @config = {}
+      options.reverse_merge!(engine_config) if engine_config
+      options.reverse_merge!(DEFAULT_CONFIG)
+      configure options
+    end
+
+    def default?
+      DEFAULT_CONFIG.sort == config.sort
+    end
+
+    def configure(options = {})
+      @config.merge! validate_config!(options)
+
+      config.each do |key,value|
+        send("#{key}=", value)
+      end
+    end
+
+    private
+
+      def engine_config
+        @engine_config ||= WashOut::Engine.config.wash_out
+      end
+
+      def validate_config!(options = {})
+        rejected_keys = options.keys.reject do |key|
+          WashOut::SoapConfig.keys.include?(key)
+        end
+
+        if rejected_keys.any?
+          raise "The following keys are not allows: #{rejected_keys}\n Did you intend for one of the following? #{WashOut::SoapConfig.keys}"
+        end
+        options
+      end
+  end
+end

--- a/lib/wash_out/type.rb
+++ b/lib/wash_out/type.rb
@@ -1,5 +1,6 @@
 module WashOut
   class Type
+
     def self.type_name(value)
       @param_type_name = value
     end
@@ -13,15 +14,15 @@ module WashOut
       @param_map
     end
 
-    def self.wash_out_param_name
+    def self.wash_out_param_name(soap_config = nil)
+      soap_config ||= WashOut::SoapConfig.new({})
       @param_type_name ||= name.underscore.gsub '/', '.'
 
-      if WashOut::Engine.camelize_wsdl.to_s == 'lower'
+      if soap_config.camelize_wsdl.to_s == 'lower'
         @param_type_name = @param_type_name.camelize(:lower)
-      elsif WashOut::Engine.camelize_wsdl
+      elsif soap_config.camelize_wsdl
         @param_type_name = @param_type_name.camelize
       end
-
       @param_type_name
     end
   end

--- a/lib/wash_out/wsse.rb
+++ b/lib/wash_out/wsse.rb
@@ -1,15 +1,16 @@
 module WashOut
   class Wsse
-
-    def self.authenticate(token)
-      wsse = self.new(token)
+    attr_reader :soap_config
+    def self.authenticate(soap_config, token)
+      wsse = self.new(soap_config, token)
 
       unless wsse.eligible?
         raise WashOut::Dispatcher::SOAPError, "Unauthorized"
       end
     end
 
-    def initialize(token)
+    def initialize(soap_config, token)
+      @soap_config = soap_config
       if token.blank? && required?
         raise WashOut::Dispatcher::SOAPError, "Missing required UsernameToken"
       end
@@ -17,15 +18,15 @@ module WashOut
     end
 
     def required?
-      !WashOut::Engine.wsse_username.blank?
+      !soap_config.wsse_username.blank?
     end
 
     def expected_user
-      WashOut::Engine.wsse_username
+      soap_config.wsse_username
     end
 
     def expected_password
-      WashOut::Engine.wsse_password
+      soap_config.wsse_password
     end
 
     def matches_expected_digest?(password)

--- a/spec/lib/wash_out/dispatcher_spec.rb
+++ b/spec/lib/wash_out/dispatcher_spec.rb
@@ -5,7 +5,7 @@ require 'spec_helper'
 describe WashOut::Dispatcher do
 
   class Dispatcher < ApplicationController
-    include WashOut::SOAP
+    soap_service
 
     def self.mock(text="")
       dispatcher = self.new
@@ -60,27 +60,27 @@ describe WashOut::Dispatcher do
 
   describe "#_load_params" do
     let(:dispatcher) { Dispatcher.new }
-
+    let(:soap_config) { WashOut::SoapConfig.new({ camelize_wsdl: false }) }
     it "should load params for an array" do
-      spec = WashOut::Param.parse_def( {:my_array => [:integer] } )
+      spec = WashOut::Param.parse_def(soap_config, {:my_array => [:integer] } )
       xml_data = {:my_array => [1, 2, 3]}
       dispatcher._load_params(spec, xml_data).should == {"my_array" => [1, 2, 3]}
     end
 
     it "should load params for an empty array" do
-      spec = WashOut::Param.parse_def( {:my_array => [:integer] } )
+      spec = WashOut::Param.parse_def(soap_config, {:my_array => [:integer] } )
       xml_data = {}
       dispatcher._load_params(spec, xml_data).should == {}
     end
 
     it "should load params for a nested array" do
-      spec = WashOut::Param.parse_def( {:nested => {:my_array => [:integer]}} )
+      spec = WashOut::Param.parse_def(soap_config, {:nested => {:my_array => [:integer]}} )
       xml_data = {:nested => {:my_array => [1, 2, 3]}}
       dispatcher._load_params(spec, xml_data).should == {"nested" => {"my_array" => [1, 2, 3]}}
     end
 
     it "should load params for an empty nested array" do
-      spec = WashOut::Param.parse_def( {:nested => {:empty => [:integer] }} )
+      spec = WashOut::Param.parse_def(soap_config, {:nested => {:empty => [:integer] }} )
       xml_data = {:nested => nil}
       dispatcher._load_params(spec, xml_data).should == {"nested" => {}}
     end

--- a/spec/lib/wash_out/type_spec.rb
+++ b/spec/lib/wash_out/type_spec.rb
@@ -5,9 +5,11 @@ require 'spec_helper'
 describe WashOut::Type do
 
   it "defines custom type" do
+
     class Abraka1 < WashOut::Type
       map :test => :string
     end
+
     class Abraka2 < WashOut::Type
       type_name 'test'
       map :foo => Abraka1

--- a/spec/lib/wash_out_spec.rb
+++ b/spec/lib/wash_out_spec.rb
@@ -3,11 +3,6 @@
 require 'spec_helper'
 
 describe WashOut do
-  before :each do
-    WashOut::Engine.snakecase_input = true
-    WashOut::Engine.camelize_wsdl   = true
-    WashOut::Engine.namespace       = false
-  end
 
   let :nori do
     Nori.new(
@@ -54,11 +49,12 @@ describe WashOut do
       mock_controller do
         soap_action :result, :args => nil, :return => :int
 
-        soap_action "getArea", :args   => { :circle => [{ :center => { :x => [:integer],
-                                                                      :y => :integer },
-                                                         :radius => :double }] },
-                               :return => { :area => :double }
-
+        soap_action "getArea", :args => {
+          :circle => [{
+            :center => { :x => [:integer], :y => :integer },
+            :radius => :double
+          }]},
+          :return => { :area => :double }
         soap_action "rocky", :args   => { :circle1 => { :x => :integer } },
                              :return => { :circle2 => { :y => :integer } }
       end
@@ -429,7 +425,7 @@ describe WashOut do
     context "errors" do
       it "raise for incorrect requests" do
         mock_controller do
-          soap_action "duty", 
+          soap_action "duty",
             :args => {:bad => {:a => :string, :b => :string}, :good => {:a => :string, :b => :string}},
             :return => nil
           def duty
@@ -564,10 +560,7 @@ describe WashOut do
     end
 
     it "handles snakecase option properly" do
-      WashOut::Engine.snakecase_input = false
-      WashOut::Engine.camelize_wsdl   = false
-
-      mock_controller do
+      mock_controller(snakecase_input: false, camelize_wsdl: false) do
         soap_action "rocknroll", :args => {:ZOMG => :string}, :return => nil
         def rocknroll
           params["ZOMG"].should == "yam!"
@@ -583,10 +576,7 @@ describe WashOut do
   describe "WS Security" do
 
     it "appends username_token to params" do
-      WashOut::Engine.wsse_username = nil
-      WashOut::Engine.wsse_password = nil
-
-      mock_controller do
+      mock_controller(wsse_username: "gorilla", wsse_password: "secret") do
         soap_action "checkToken", :args => :integer, :return => nil, :to => 'check_token'
         def check_token
           request.env['WSSE_TOKEN']['username'].should == "gorilla"
@@ -601,10 +591,7 @@ describe WashOut do
     end
 
     it "handles PasswordText auth" do
-      WashOut::Engine.wsse_username = "gorilla"
-      WashOut::Engine.wsse_password = "secret"
-
-      mock_controller do
+      mock_controller(wsse_username: "gorilla", wsse_password: "secret") do
         soap_action "checkAuth", :args => :integer, :return => :boolean, :to => 'check_auth'
         def check_auth
           render :soap => (params[:value] == 42)
@@ -629,10 +616,7 @@ describe WashOut do
     end
 
     it "handles PasswordDigest auth" do
-      WashOut::Engine.wsse_username = "gorilla"
-      WashOut::Engine.wsse_password = "secret"
-
-      mock_controller do
+      mock_controller(wsse_username: "gorilla", wsse_password: "secret") do
         soap_action "checkAuth", :args => :integer, :return => :boolean, :to => 'check_auth'
         def check_auth
           render :soap => (params[:value] == 42)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -27,9 +27,11 @@ RSpec.configure do |config|
 
   config.mock_with :rspec
   config.before(:all) do
-    WashOut::Engine.snakecase_input = false
-    WashOut::Engine.camelize_wsdl   = false
-    WashOut::Engine.namespace       = false
+    WashOut::Engine.config.wash_out = {
+      snakecase_input: false,
+      camelize_wsdl: false,
+      namespace: false
+    }
   end
 
   config.after(:suite) do
@@ -51,11 +53,14 @@ Dummy::Application.routes.draw do
   wash_out :api
 end
 
-def mock_controller(&block)
+def mock_controller(options = {}, &block)
   Object.send :remove_const, :ApiController if defined?(ApiController)
   Object.send :const_set, :ApiController, Class.new(ApplicationController) {
-    include WashOut::SOAP
-
+    soap_service options.reverse_merge({
+      snakecase_input: true,
+      camelize_wsdl: true,
+      namespace: false
+    })
     class_exec &block if block
   }
 

--- a/wash_out.gemspec
+++ b/wash_out.gemspec
@@ -12,6 +12,9 @@ Gem::Specification.new do |s|
 
   s.files         = `git ls-files`.split("\n")
   s.require_paths = ["lib"]
-
+  s.post_install_message = <<-EOS
+    Please replace `include WashOut::SOAP` with `soap_service`
+    in your controllers if you are upgrading from a version before 0.8.5.
+  EOS
   s.add_dependency("nori", ">= 2.0.0")
 end


### PR DESCRIPTION
This is just a start, it is mostly working in regards to being backwards compatible but I haven't added any specific tests or such for the new functionality. I will rebase against master as soon as you say go.

There seems to be some sort of situation with the auth specific configuration options not being set properly.

If I change from global configuration `WashOut::Engine.configure_soap wsse_username: "gorilla", wsse_password: "secret"` to the below it seems like the engine does not pick these up at all. Do we need to restart it?

``` ruby
    it "handles PasswordText auth" do 
      mock_controller do
        configure_soap wsse_username: "gorilla",
                       wsse_password: "secret"
        soap_action "checkAuth", :args => :integer, :return => :boolean, :to => 'check_auth'
        def check_auth
          render :soap => (params[:value] == 42)
        end
      end
  end
```
