### PR TITLE
Update Readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ To override the values on a specific controller just add an override as part of 
 Available properties are:
 
 * **parser**: XML parser to use – `:rexml` or `:nokogiri`. The first one is default but the latter is much faster. Be sure to add `gem nokogiri` if you want to use it.
-* **style**: sets WSDL style. Supported values are: 'document' and 'rpc'.
+* **wsdl_style**: sets WSDL style. Supported values are: 'document' and 'rpc'.
 * **catch_xml_errors**: intercept Rails parsing exceptions to return correct XML response for corrupt XML input. Default is `false`.
 * **namespace**: SOAP namespace to use. Default is `urn:WashOut`.
 * **snakecase_input**: Determines if WashOut should modify parameters keys to snakecase. Default is `false`.


### PR DESCRIPTION
I renamed style to wsdl_style since style could potentially relate to the style of the soap config or engine or whatever else uses styles. 

Just remembered this breaks backwards compatibility.
