### PR TITLE
Pull request for generating html documentation

### DIFF
--- a/lib/wash_out/soap.rb
+++ b/lib/wash_out/soap.rb
@@ -31,6 +31,8 @@ module WashOut
         self.soap_actions[action] = {
           :in           => WashOut::Param.parse_def(soap_config, options[:args]),
           :out          => WashOut::Param.parse_def(soap_config, options[:return]),
+           :description => options[:description],
+          :raises       => options[:raises],
           :to           => options[:to] || action,
           :response_tag => options[:response_tag] || default_response_tag
         }


### PR DESCRIPTION
I need to add two attributes to the WashOut::Param in order to be able to use this to generate documentation 
and two new options for WashOut::Soap to specify a description for each action and a list with possible exceptions that the method can raise.  

( This is as a result of this pull request https://github.com/inossidabile/wash_out/pull/125 )
( this feature is made in another gem that is going to be dependent on this gem, not yet published ) 
