### PR TITLE
ArgumentError when using activerecord models when defining a Washout::Type

### DIFF
--- a/lib/wash_out/param.rb
+++ b/lib/wash_out/param.rb
@@ -100,7 +100,7 @@ module WashOut
 
     def basic_type
       return name unless classified?
-      return source_class.wash_out_param_name(@soap_config)
+      return source_class.wash_out_param_name
     end
 
     def xsd_type


### PR DESCRIPTION
when you define a washout type that contains also a activerecord model it fails with  ArgumentError  and messsage:
wrong number of arguments (1 for 0)

The issue was in Washout::Param class , the method basic_type

```
def basic_type
  return name unless classified?
  return source_class.wash_out_param_name(@soap_config)
end
```

But in Washout::Model the method  wash_out_param_name doesn't need any arguments

So i removed that argument when the function is called 
