### PR TITLE
Maintain 'source_class' of the param across a copy

### DIFF
--- a/lib/wash_out/param.rb
+++ b/lib/wash_out/param.rb
@@ -160,6 +160,7 @@ module WashOut
     def flat_copy
       copy = self.class.new(@soap_config, @name, @type.to_sym, @multiplied)
       copy.raw_name = raw_name
+      copy.source_class = copy.source_class
       copy
     end
 


### PR DESCRIPTION
When generating the SOAP Response the type of a return complexType wasn't being included, this meant the response didn't match the WSDL specification.

Maintaining the 'source_class' when copying a param allows the response XML to include the correct type for that message part.

WSDL Snippet:

```
<xsd:complexType name="OslStruct">
  <xsd:sequence>
    <xsd:element name="result" type="xsd:boolean"/>
    <xsd:element name="message" type="xsd:string"/>
  </xsd:sequence>
</xsd:complexType>

...

<message name="add_property_response">
  <part name="return" type="tns:OslStruct"/>
</message>
```

Before the change, the response would look like:

```
<?xml version="1.0" encoding="UTF-8"?>
<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tns="urn:WashOut">
  <soap:Body>
    <tns:add_property_response>
      <return xsi:type="tns:return">
        <result xsi:type="xsd:boolean">false</result>
        <message xsi:type="xsd:string">Could not perform import (agency ID not recognised)</message>
      </return>
    </tns:add_property_response>
  </soap:Body>
</soap:Envelope>
```

And after it looks like

```
?xml version="1.0" encoding="UTF-8"?>
<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tns="urn:WashOut">
  <soap:Body>
    <tns:add_property_response>
      <return xsi:type="tns:OslStruct">
        <result xsi:type="xsd:boolean">false</result>
        <message xsi:type="xsd:string">Could not perform import (agency ID not recognised)</message>
      </return>
    </tns:add_property_response>
  </soap:Body>
</soap:Envelope>
```

To me, the later is more correct?
