### PR TITLE
Make snake_casing consistent

### DIFF
--- a/lib/wash_out/router.rb
+++ b/lib/wash_out/router.rb
@@ -18,7 +18,7 @@ module WashOut
       soap_action = env['HTTP_SOAPACTION'].to_s.gsub(/^"(.*)"$/, '\1')
 
       if soap_action.blank?
-        soap_action = nori.parse(soap_body env)
+        soap_action = nori(controller.soap_config.snakecase_input).parse(soap_body env)
             .values_at(:envelope, :Envelope).compact.first
             .values_at(:body, :Body).compact.first
             .keys.first.to_s
@@ -41,7 +41,7 @@ module WashOut
         :strip_namespaces => true,
         :advanced_typecasting => true,
         :convert_tags_to => (
-          snakecase ? lambda { |tag| tag.snakecase.to_sym } 
+          snakecase ? lambda { |tag| tag.snakecase.to_sym }
                     : lambda { |tag| tag.to_sym }
         )
       )


### PR DESCRIPTION
For the following request:

``` xml
<env:Envelope
  xmlns:xsd="http://www.w3.org/2001/XMLSchema"
  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
  xmlns:tns="http://types.walletserver.casinomodule.com/3_0/"
  xmlns:env="http://schemas.xmlsoap.org/soap/envelope/">
  <env:Body>
    <tns:Deposit>
      <callerId>id</callerId>
      <callerPassword>pass</callerPassword>
      <playerName>mhenrixon</playerName>
      <amount>3.7</amount>
      <bonusPrograms>
        <bonus>
          <bonusProgramId>3</bonusProgramId>
          <depositionId>1</depositionId>
        </bonus>
        <bonus>
          <bonusProgramId>3</bonusProgramId>
          <depositionId>2</depositionId>
        </bonus>
      </bonusPrograms>
      <currency>EUR</currency>
      <transactionRef>11457</transactionRef>
      <reason>WAGERED_BONUS</reason>
    </tns:Deposit>
  </env:Body>
</env:Envelope>
```

I was getting errors saying "Deposit" could not be found. This commit
fixes that problem and ensures not only snake casing of parameters but
also of soap actions.

This is my `soap_config`

``` ruby
      soap_service camelize_wsdl:   :lower,
                   wsdl_style:      :document,
                   snakecase_input: true,
                   namespace:       'http://types.walletserver.casinomodule.com/3_0/'

      soap_action :get_player_currency,
                  args:   WalletServer::Currency,
                  error:  WalletServer::Fault,
                  return: WalletServer::CurrencyResponse,
                  to:     :currency
```
