### PR TITLE
Return a valid response for the trivial case when soap body is empty

### DIFF
--- a/lib/wash_out/router.rb
+++ b/lib/wash_out/router.rb
@@ -19,7 +19,10 @@ module WashOut
                                                                : ''
 
       if soap_action.blank?
-        soap_action = nori(controller.soap_config.snakecase_input).parse(soap_body env)
+        parsed_soap_body = nori(controller.soap_config.snakecase_input).parse(soap_body env)
+        return nil if parsed_soap_body.blank?
+
+        soap_action = parsed_soap_body
             .values_at(:envelope, :Envelope).compact.first
             .values_at(:body, :Body).compact.first
             .keys.first.to_s
@@ -74,6 +77,8 @@ module WashOut
       @controller = @controller_name.constantize
 
       soap_action     = parse_soap_action(env)
+      return [200, {}, ['OK']] if soap_action.blank?
+
       soap_parameters = parse_soap_parameters(env)
 
       action_spec = controller.soap_actions[soap_action]

--- a/spec/lib/wash_out/router_spec.rb
+++ b/spec/lib/wash_out/router_spec.rb
@@ -1,0 +1,22 @@
+require 'spec_helper'
+require 'wash_out/router'
+
+describe WashOut::Router do
+  it 'returns a 200 with empty soap action' do
+
+    mock_controller do
+      # nothing
+    end
+
+    env = {}
+    env['REQUEST_METHOD'] = 'GET'
+    env['rack.input'] = double 'basic-rack-input', {:string => ''}
+    result = WashOut::Router.new('Api').call env
+
+    expect(result[0]).to eq(200)
+    #expect(result[1]['Content-Type']).to eq('text/xml')
+
+    msg = result[2][0]
+    expect(msg).to eq('OK')
+  end
+end


### PR DESCRIPTION
Fixes https://github.com/skryl/qbwc/issues/30 by permitting a non-SOAP request (for obtaining https certificate) to respond successfully.
