### PR TITLE
Add an `:as` option to `soap_action`

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,20 @@ class RumbasController < ApplicationController
     render :soap => params[:data].map{|x| x ? 1 : 0}
   end
 
+  # With a customised input tag name, in case params are wrapped;
+  # e.g. for a request to the 'IntegersToBoolean' action:
+  #   <soapenv:Envelope>
+  #     <soapenv:Body>
+  #       <MyRequest>  <!-- not <IntegersToBoolean> -->
+  #         <Data>...</Data>
+  #       </MyRequest>
+  #     </soapenv:Body>
+  #   </soapenv:Envelope>
+  soap_action "integers_to_boolean",
+              :args => { :my_request => { :data => [:integer] } },
+              :as => 'MyRequest'
+              :return => [:boolean]
+
   # You can use all Rails features like filtering, too. A SOAP controller
   # is just like a normal controller with a special routing.
   before_filter :dump_parameters

--- a/lib/wash_out/dispatcher.rb
+++ b/lib/wash_out/dispatcher.rb
@@ -188,6 +188,10 @@ module WashOut
       self.class.soap_actions[soap_action]
     end
 
+    def request_input_tag
+      action_spec[:request_tag]
+    end
+
     def soap_action
       request.env['wash_out.soap_action']
     end
@@ -195,7 +199,7 @@ module WashOut
     def xml_data
       xml_data = env['wash_out.soap_data'].values_at(:envelope, :Envelope).compact.first
       xml_data = xml_data.values_at(:body, :Body).compact.first
-      xml_data = xml_data.values_at(soap_action.underscore.to_sym, soap_action.to_sym).compact.first || {}
+      xml_data = xml_data.values_at(soap_action.underscore.to_sym, soap_action.to_sym, request_input_tag.to_sym).compact.first || {}
     end
 
   end

--- a/lib/wash_out/soap.rb
+++ b/lib/wash_out/soap.rb
@@ -30,6 +30,7 @@ module WashOut
 
         self.soap_actions[action] = options.merge(
           :in           => WashOut::Param.parse_def(soap_config, options[:args]),
+          :request_tag  => options[:as] || action,
           :out          => WashOut::Param.parse_def(soap_config, options[:return]),
           :to           => options[:to] || action,
           :response_tag => options[:response_tag] || default_response_tag


### PR DESCRIPTION
#### Overview
This PR gives `soap_action` the ability to wrap input parameters in a child element that has a different name to the action. The option is added to the action configuration.

#### Example
In an app's controller:
```ruby
soap_action "integers_to_boolean",
  :args => { 
    :data => [:integer]
  },
  :as => 'AllMyIntegers'
```
allows for a client to make a request of:
```xml
<soapenv:Envelope>
  <soapenv:Body>
    <AllMyIntegers>  <-- instead of IntegersToBoolean, or no wrapping tag at all -->
      <Data>...</Data>
    </AllMyIntegers>
  </soapenv:Body>
</soapenv:Envelope>
```
The params would now be extracted as ```{ :data => 123 }``` rather than ```{ :all_my_integers => { :data => 123 } }```.

#### Why did I make this PR?
I'm currently using WashOut to make a mock SOAP service, that mimics an existing one with a few quirks. This existing service has a ```ContactsSearch``` action but accepts a request:
```xml
<soapenv:Envelope>
  <soapenv:Body>
    <GenericSearchRequest>
      <FirstName>...</Firstname>
      <LastName>...</LastName>
    </GenericSearchRequest>
  </soapenv:Body>
</soapenv:Envelope>
```
This probably means that it doesn't conform to standard, but this might be experienced by others working to replace an existing service.

#### TODO
* SoapUI does not detect the setting when fetching the WSDL for sample requests, I imagine the builders in `app/views` will need to consider this setting.
* I can't quite figure out the unit tests yet otherwise I'd have added some there!