### PR TITLE
Add long type param

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ before_install:
 script: "bundle exec rspec"
 rvm:
   - 1.9.3
-  - jruby-19mode
   - 2.0.0
-  - 2.1.0
+  - 2.1.8
+  - 2.2.4
+  - 2.3.0
+  - jruby-19mode

--- a/lib/wash_out/param.rb
+++ b/lib/wash_out/param.rb
@@ -64,6 +64,7 @@ module WashOut
         operation = case type
           when 'string';       :to_s
           when 'integer';      :to_i
+          when 'long';         :to_i
           when 'double';       :to_f
           when 'boolean';      lambda{|dat| dat === "0" ? false : !!dat}
           when 'date';         :to_date

--- a/spec/lib/wash_out/param_spec.rb
+++ b/spec/lib/wash_out/param_spec.rb
@@ -60,13 +60,25 @@ describe WashOut::Param do
     end
   end
 
+  describe 'longs' do
+    let(:soap_config) { WashOut::SoapConfig.new({ camelize_wsdl: false }) }
+    let(:map) { WashOut::Param.parse_def(soap_config, :value => :long) }
+
+    it "should accept positive long" do
+      expect(map[0].load({:value => 9223372036854775807}, :value)).to eq 9223372036854775807
+    end
+
+    it "should accept negative long" do
+      expect(map[0].load({:value => -9223372036854775807}, :value)).to eq -9223372036854775807
+    end
+  end
 
   describe '#flat_copy' do
     it 'should copy everything' do
       soap_config = WashOut::SoapConfig.new({})
       type = :foo
       multiplied = "of course"
-      
+
       param = WashOut::Param.new(soap_config, 'name', type, multiplied)
       param.source_class = "middle class"
       evil_clone = param.flat_copy


### PR DESCRIPTION
Hello there! We have a client that uses a `long` type XML element, and I had to add this kind of parameter to accept applications of their own.

I know, it's exactly the same as `integer` type at background, but you know.... some things on SOAP doesn't....