### PR TITLE
Update soap.rb

### DIFF
--- a/lib/wash_out/soap.rb
+++ b/lib/wash_out/soap.rb
@@ -27,14 +27,15 @@ module WashOut
 
         default_response_tag = soap_config.camelize_wsdl ? 'Response' : '_response'
         default_response_tag = action+default_response_tag
-
-        self.soap_actions[action] = options.merge(
-          :in           => WashOut::Param.parse_def(soap_config, options[:args]),
-          :request_tag  => options[:as] || action,
-          :out          => WashOut::Param.parse_def(soap_config, options[:return]),
-          :to           => options[:to] || action,
-          :response_tag => options[:response_tag] || default_response_tag
-        )
+        if ActiveRecord::Base.connection.tables.present?
+          self.soap_actions[action] = options.merge(
+            :in           => WashOut::Param.parse_def(soap_config, options[:args]),
+            :request_tag  => options[:as] || action,
+            :out          => WashOut::Param.parse_def(soap_config, options[:return]),
+            :to           => options[:to] || action,
+            :response_tag => options[:response_tag] || default_response_tag
+          )
+        end
       end
     end
 


### PR DESCRIPTION
Prevent access to the database before the migration's done when deploying with Rails 4.0