### PR TITLE
integers_to_boolean should accept Integers and return Booleans

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ class RumbasController < ApplicationController
               :args => { :data => [:integer] },
               :return => [:boolean]
   def integers_to_boolean
-    render :soap => params[:data].map{|x| x ? 1 : 0}
+    render :soap => params[:data].map{|i| i > 0}
   end
 
   # Params from XML attributes;


### PR DESCRIPTION
Just a small documentation change for consistency :
integers_to_boolean should return an Array of Booleans.