### PR TITLE
Set xsi:nil to true if content is nil

### DIFF
--- a/app/helpers/wash_out_helper.rb
+++ b/app/helpers/wash_out_helper.rb
@@ -3,7 +3,11 @@ module WashOutHelper
   def wsdl_data_options(param)
     case controller.soap_config.wsdl_style
     when 'rpc'
-      { :"xsi:type" => param.namespaced_type }
+      if param.map.present? || param.value
+        { :"xsi:type" => param.namespaced_type }
+      else
+        { :"xsi:nil" => true }
+      end
     when 'document'
       { }
     end

--- a/app/helpers/wash_out_helper.rb
+++ b/app/helpers/wash_out_helper.rb
@@ -100,11 +100,11 @@ module WashOutHelper
   end
 
   def wsdl_occurence(param, inject, extend_with = {})
-    data = !param.multiplied ? {} : {
-      "#{'xsi:' if inject}minOccurs" => 0,
-      "#{'xsi:' if inject}maxOccurs" => 'unbounded'
-    }
-
+    data = {"#{'xsi:' if inject}nillable" => 'true'}
+    if param.multiplied
+      data["#{'xsi:' if inject}minOccurs"] = 0
+      data["#{'xsi:' if inject}maxOccurs"] = 'unbounded'
+    end
     extend_with.merge(data)
   end
 end

--- a/spec/lib/wash_out_spec.rb
+++ b/spec/lib/wash_out_spec.rb
@@ -84,6 +84,13 @@ describe WashOut do
 
       expect(x[:'@min_occurs']).to eq "0"
       expect(x[:'@max_occurs']).to eq "unbounded"
+      expect(x[:'@nillable']).to eq "true"
+    end
+
+    it "adds nillable to all type definitions" do
+      types = xml[:definitions][:message].map { |d| d[:part] }.compact
+      nillable = types.map { |t| t[:"@xsi:nillable"] }
+      expect(nillable.all? { |v| v == "true" }).to be true
     end
   end
 

--- a/spec/lib/wash_out_spec.rb
+++ b/spec/lib/wash_out_spec.rb
@@ -152,8 +152,7 @@ describe WashOut do
             render :soap => {:a => params[:a]}
           end
         end
-        expect(savon(:answer, :a => '')[:answer_response][:a]).
-          to eq({:"@xsi:type"=>"xsd:string"})
+        expect(savon(:answer, :a => '')[:answer_response][:a]).to be_nil
       end
 
       it "accept one parameter" do
@@ -410,10 +409,20 @@ describe WashOut do
             end
           end
 
-          expect(savon(:rocknroll)[:rocknroll_response][:my_value]).
-            to eq({ 
-              :"@xsi:type" => "tns:MyValue"
-            })
+          expect(savon(:rocknroll)[:rocknroll_response][:my_value]).to be_nil
+        end
+
+        it "responds with missing parameters" do
+          mock_controller do
+            soap_action "rocknroll",
+              args: nil,
+              return: {my_value: :integer}
+            def rocknroll
+              render soap: {my_value: nil}
+            end
+          end
+
+          expect(savon(:rocknroll)[:rocknroll_response][:my_value]).to be_nil
         end
 
         it "handles incomplete array response" do


### PR DESCRIPTION
Prior to this commit the XML returned by `wash_out` for `nil` values has a empty
element but the type is marked as the type of the expected value. When
clients like Savon parse this XML they return the type instead of the value
which is actually `nil`.

With this commit if the value is passed in is nil then `xsi:nil` will be set to
`true` on the element instead of the type. Now when clients like Savon parse the
XML they will return the actual given value `nil` instead of the type the
element was supposed to have.

> xsi:nil is "a mechanism for signaling that an element should be accepted as ·valid· when it has no
content despite a content type which does not require or even necessarily allow
empty content. An element may be ·valid· without content if it has the attribute
xsi:nil with the value true. An element so labeled must be empty, but can carry
attributes if permitted by the corresponding complex type."

https://www.w3.org/TR/xmlschema-1/#xsi_nil

In order to move our existing SOAP API to `wash_out` we need to fields that sometimes return `nil` values. This is the behavior we desire. I could easily add a setting to the `Config` that would make this behavior optional if you don't want this to be the standard.