### PR TITLE
Fix `deep_replace_href` and `deep_select` to work with Arrays

### DIFF
--- a/lib/wash_out/router.rb
+++ b/lib/wash_out/router.rb
@@ -61,9 +61,8 @@ module WashOut
 
     def parse_soap_parameters(env)
       return env['wash_out.soap_data'] if env['wash_out.soap_data']
-
       env['wash_out.soap_data'] = nori(controller.soap_config.snakecase_input).parse(soap_body env)
-      references = WashOut::Dispatcher.deep_select(env['wash_out.soap_data']){|k,v| v.is_a?(Hash) && v.has_key?(:@id)}
+      references = WashOut::Dispatcher.deep_select(env['wash_out.soap_data'])
 
       unless references.blank?
         replaces = {}; references.each{|r| replaces['#'+r[:@id]] = r}

--- a/spec/fixtures/nested_refs_to_arrays.xml
+++ b/spec/fixtures/nested_refs_to_arrays.xml
@@ -1,0 +1,19 @@
+<s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/">
+  <s:Body s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <parent href="#id1" />
+    <q2:child id="id1" xsi:type="q2:child" xmlns:q2="urn:FakeService">
+      <first_list href="#id2" />
+      <second_list href="#id3" />
+    </q2:child>
+    <q3:Array id="id2" q3:arrayType="xsd:int[1]" xmlns:q3="http://schemas.xmlsoap.org/soap/encoding/">
+      <Item>1</Item>
+      <Item>2</Item>
+    </q3:Array>
+    <q4:Array id="id3" q4:arrayType="xsd:int[1]" xmlns:q4="http://schemas.xmlsoap.org/soap/encoding/">
+      <Item>11</Item>
+      <Item>22</Item>
+    </q4:Array>
+  </s:Body>
+</s:Envelope>

--- a/spec/fixtures/ref_to_one_array.xml
+++ b/spec/fixtures/ref_to_one_array.xml
@@ -1,0 +1,11 @@
+<s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/">
+  <s:Body s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <list href="#id1" />
+    <q1:Array id="id1" q1:arrayType="xsd:int[1]" xmlns:q1="http://schemas.xmlsoap.org/soap/encoding/">
+      <Item>1</Item>
+      <Item>2</Item>
+    </q1:Array>
+  </s:Body>
+</s:Envelope>

--- a/spec/fixtures/refs_to_arrays.xml
+++ b/spec/fixtures/refs_to_arrays.xml
@@ -1,0 +1,16 @@
+<s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/">
+  <s:Body s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <first_list href="#id1" />
+    <second_list href="#id2" />
+    <q1:Array id="id1" q1:arrayType="xsd:int[1]" xmlns:q1="http://schemas.xmlsoap.org/soap/encoding/">
+      <Item>1</Item>
+      <Item>2</Item>
+    </q1:Array>
+    <q2:Array id="id2" q2:arrayType="xsd:int[1]" xmlns:q2="http://schemas.xmlsoap.org/soap/encoding/">
+      <Item>11</Item>
+      <Item>22</Item>
+    </q2:Array>
+  </s:Body>
+</s:Envelope>

--- a/spec/lib/wash_out/router_spec.rb
+++ b/spec/lib/wash_out/router_spec.rb
@@ -19,4 +19,35 @@ describe WashOut::Router do
     msg = result[2][0]
     expect(msg).to eq('OK')
   end
+
+  def parse_soap_params_from_xml(filename)
+    xml = File.read(File.expand_path("../../../fixtures/#{filename}", __FILE__))
+    env = {'rack.input' => StringIO.new(xml)}
+
+    router = WashOut::Router.new('')
+    controller = double("controller", soap_config: WashOut::SoapConfig.new)
+    allow(router).to receive(:controller).and_return(controller)
+
+    router.parse_soap_parameters(env)[:Envelope][:Body]
+  end
+
+  it "returns refs to arrays correctly" do
+    body = parse_soap_params_from_xml('ref_to_one_array.xml')
+
+    expect(body[:list][:Item]).to eq(["1", "2"])
+  end
+
+  it "returns refs to multiple arrays correctly" do
+    body = parse_soap_params_from_xml('refs_to_arrays.xml')
+
+    expect(body[:first_list][:Item]).to eq(["1", "2"])
+    expect(body[:second_list][:Item]).to eq(["11", "22"])
+  end
+
+  it "returns nested refs to multiple arrays correctly" do
+    body = parse_soap_params_from_xml('nested_refs_to_arrays.xml')
+
+    expect(body[:parent][:first_list][:Item]).to eq(["1", "2"])
+    expect(body[:parent][:second_list][:Item]).to eq(["11", "22"])
+  end
 end


### PR DESCRIPTION
I added the fixtures `refs_to_arrays.xml` and `nested_refs_to_arrays.xml`. Both are valid XML that was not able to be correctly parsed by `wash_out`. It didn't crash but not all refs were present and correctly replaced in the `params` passed to the `soap_action`.

I added tests to the router that attempt to parse these XML requests into `params`. These tests exercise a method on the router that should probably be private so I'm not sure you will want to keep them. However, onlywith these tests I was able to track down the problem to bugs in `deep_select`.

`deep_select` didn't support finding elements inside arrays. I added unit tests to the `dispatcher_spec` to show these cases. In order to make it easier to test that `deep_select` was working properly, I changed its signature so that it doesn't take a block and it always just selects
ids. This was the only use of the method.

I also discovered that searching through arrays was also not supported by `deep_replace_href`. Unit
tests were adding showing these bugs and now this function can also replace arrays in
nested hashes.

`deep_replace_href` and `deep_select` are now much more complex and hard to read, but changes were needed in order to be able to parse the `params` out of valid XML in more cases.