### PR TITLE
Handle values of type 'int' the same as 'integer's.

### DIFF
--- a/lib/wash_out/param.rb
+++ b/lib/wash_out/param.rb
@@ -63,6 +63,7 @@ module WashOut
       else
         operation = case type
           when 'string';       :to_s
+          when 'int';          :to_i
           when 'integer';      :to_i
           when 'long';         :to_i
           when 'double';       :to_f

--- a/spec/lib/wash_out/param_spec.rb
+++ b/spec/lib/wash_out/param_spec.rb
@@ -60,6 +60,20 @@ describe WashOut::Param do
     end
   end
 
+  describe "integers" do
+    let(:soap_config) { WashOut::SoapConfig.new({ camelize_wsdl: false }) }
+
+    it "accepts them as 'integer'" do
+      map = WashOut::Param.parse_def(soap_config, :value => :integer)
+      expect(map[0].load({value: '42'}, :value)).to eq 42
+    end
+
+    it "accepts them as 'int'" do
+      map = WashOut::Param.parse_def(soap_config, :value => :int)
+      expect(map[0].load({value: '42'}, :value)).to eq 42
+    end
+  end
+
   describe 'longs' do
     let(:soap_config) { WashOut::SoapConfig.new({ camelize_wsdl: false }) }
     let(:map) { WashOut::Param.parse_def(soap_config, :value => :long) }


### PR DESCRIPTION
Fixes #198.