### PR TITLE
Change before hooks conditions so non-soap endpoints don't call soap methods

### DIFF
--- a/lib/wash_out/dispatcher.rb
+++ b/lib/wash_out/dispatcher.rb
@@ -166,10 +166,8 @@ module WashOut
 
       controller.send :"around_#{entity}", :_catch_soap_errors
       controller.send :helper, :wash_out
-      controller.send :"before_#{entity}", :_authenticate_wsse,     :except => [
-        :_generate_wsdl, :_invalid_action ]
-      controller.send :"before_#{entity}", :_map_soap_parameters,   :except => [
-        :_generate_wsdl, :_invalid_action ]
+      controller.send :"before_#{entity}", :_authenticate_wsse,   :if => :soap_action?
+      controller.send :"before_#{entity}", :_map_soap_parameters, :if => :soap_action?
       controller.send :"skip_before_#{entity}", :verify_authenticity_token
     end
 
@@ -209,6 +207,10 @@ module WashOut
     end
 
     private
+    def soap_action?
+      soap_action.present?
+    end
+
     def action_spec
       self.class.soap_actions[soap_action]
     end


### PR DESCRIPTION
I found that if I try to add additional, non-SOAP, methods to a wash_out controller, some of the before_action/filter hooks (particularly the `_map_soap_parameters` method) fail. The current `except` option is too open and means that any additional endpoints will call those SOAP methods no matter what. This PR only applies the filters if the incoming request is a SOAP request.
