### PR TITLE
Respond with SOAP Fault to invalid SOAP requests

### DIFF
--- a/lib/wash_out/dispatcher.rb
+++ b/lib/wash_out/dispatcher.rb
@@ -140,6 +140,11 @@ module WashOut
       render_soap_error("Cannot find SOAP action mapping for #{request.env['wash_out.soap_action']}")
     end
 
+    # This action is a fallback for invalid SOAP message.
+    def _invalid_soap
+      render_soap_error("Cannot parse SOAP message: #{request.env['wash_out.soap_error']}")
+    end
+
     def _catch_soap_errors
       yield
     rescue SOAPError => error

--- a/spec/fixtures/invalid_no_body.xml
+++ b/spec/fixtures/invalid_no_body.xml
@@ -1,0 +1,6 @@
+<s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/">
+  <q1:Array id="id1" q1:arrayType="xsd:int[1]" xmlns:q1="http://schemas.xmlsoap.org/soap/encoding/">
+    <Item>1</Item>
+    <Item>2</Item>
+  </q1:Array>
+</s:Envelope>

--- a/spec/fixtures/invalid_no_envelope.xml
+++ b/spec/fixtures/invalid_no_envelope.xml
@@ -1,0 +1,10 @@
+<s:Body xmlns:s="http://schemas.xmlsoap.org/soap/envelope/"
+  s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <list href="#id1" />
+  <q1:Array id="id1" q1:arrayType="xsd:int[1]" xmlns:q1="http://schemas.xmlsoap.org/soap/encoding/">
+    <Item>1</Item>
+    <Item>2</Item>
+  </q1:Array>
+</s:Body>


### PR DESCRIPTION
Currently when you POST empty request or request not wrapped with SOAP tags you will get just obscure exception somewhere from wash_out internals (or status 500 and HTML error page in production):

    NoMethodError (undefined method `values_at' for nil:NilClass):
      wash_out lib/wash_out/dispatcher.rb:197:in `xml_data'
      wash_out lib/wash_out/dispatcher.rb:50:in `_map_soap_parameters'

Clients (human testers that POSTs junk to you, or some thick enterprise systems that don't let to see failed request but only some mystical java exception or anything) aren't like that behaviour.

With this PR wash_out will generate correct SOAP Fault with meaningful error description in case when request misses `Envelope` or `Body` tags.

Also sometimes you have to respond with custom SOAP fault every time you can't handle request, no matter was it valid or not. So I added separate method `_invalid_soap` to redefine it in controller and render appropriate fault.