### PR TITLE
[WIP] Add option to make all message tags in both request and response to be in target namespace

### DIFF
--- a/app/helpers/wash_out_helper.rb
+++ b/app/helpers/wash_out_helper.rb
@@ -13,6 +13,12 @@ module WashOutHelper
     end
   end
 
+  def wsdl_schema_attrs
+    attrs = {}
+    attrs[:elementFormDefault] = 'qualified' if controller.soap_config.qualified_tags # All tags are in target namespace
+    attrs
+  end
+
   def wsdl_data_attrs(param)
     param.map.reduce({}) do |memo, p|
       if p.respond_to?(:attribute?) && p.attribute?
@@ -27,7 +33,7 @@ module WashOutHelper
     params.each do |param|
       next if param.attribute?
 
-      tag_name = param.name
+      tag_name = controller.soap_config.qualified_tags ? "tns:#{param.name}" : param.name
       param_options = wsdl_data_options(param)
       param_options.merge! wsdl_data_attrs(param)
 

--- a/app/views/wash_out/document/wsdl.builder
+++ b/app/views/wash_out/document/wsdl.builder
@@ -9,7 +9,7 @@ xml.definitions 'xmlns' => 'http://schemas.xmlsoap.org/wsdl/',
                 'targetNamespace' => @namespace do
 
   xml.types do
-    xml.tag! "schema", :targetNamespace => @namespace, :xmlns => 'http://www.w3.org/2001/XMLSchema' do
+    xml.tag! "schema", {:targetNamespace => @namespace, :xmlns => 'http://www.w3.org/2001/XMLSchema'}.merge(wsdl_schema_attrs) do
       defined = []
       @map.each do |operation, formats|
         (formats[:in] + formats[:out]).each do |p|

--- a/app/views/wash_out/rpc/wsdl.builder
+++ b/app/views/wash_out/rpc/wsdl.builder
@@ -9,7 +9,7 @@ xml.definitions 'xmlns' => 'http://schemas.xmlsoap.org/wsdl/',
                 'name' => @name,
                 'targetNamespace' => @namespace do
   xml.types do
-    xml.tag! "schema", :targetNamespace => @namespace, :xmlns => 'http://www.w3.org/2001/XMLSchema' do
+    xml.tag! "schema", {:targetNamespace => @namespace, :xmlns => 'http://www.w3.org/2001/XMLSchema'}.merge(wsdl_schema_attrs) do
       defined = []
       @map.each do |operation, formats|
         (formats[:in] + formats[:out]).each do |p|

--- a/lib/wash_out/soap_config.rb
+++ b/lib/wash_out/soap_config.rb
@@ -7,6 +7,7 @@ module WashOut
     DEFAULT_CONFIG = {
       parser: :rexml,
       namespace: 'urn:WashOut',
+      qualified_tags: false,
       wsdl_style: 'rpc',
       snakecase_input: false,
       camelize_wsdl: false,


### PR DESCRIPTION
This PR adds a boolean flag `qualified_tags` to `soap_service` definition in controller that when enabled:

 1. Adds `elementFormDefault="qualified"` attribute to generated WSDL's `schema` tag that tells clients to generate requests with all tags inside `soap:Body` in target namespace and to expect all tags in response to be in this namespace too.
 2. Adds target namespace to all tags in response.

This will be useful when you need to implement SOAP service which conforms to existing WSDL with `elementFormDefault="qualified"` attribute specified in it's schema.

See http://stackoverflow.com/q/19954278/338859 for details.

There are no tests yet as I can't understand where to put tests for this and how to switch this flag in tests. Please tell me, how to better test this.