### PR TITLE
fix occurence in literal style wsdl

### DIFF
--- a/app/helpers/wash_out_helper.rb
+++ b/app/helpers/wash_out_helper.rb
@@ -100,6 +100,7 @@ module WashOutHelper
   end
 
   def wsdl_occurence(param, inject, extend_with = {})
+    return extend_with if controller.soap_config.wsdl_style.to_s == 'document'
     data = {"#{'xsi:' if inject}nillable" => 'true'}
     if param.multiplied
       data["#{'xsi:' if inject}minOccurs"] = 0


### PR DESCRIPTION
Literal style (which wash_out uses when `wsdl_style` is set to `document`) does not support attributes like `nillable` or `maxOccurs`.