### PR TITLE
Fixed issue with NoMethodError in ActionDispatch::Routing::Mapper with Rails 5  ( backward compatible ) 

### DIFF
--- a/lib/wash_out.rb
+++ b/lib/wash_out.rb
@@ -21,7 +21,11 @@ module ActionDispatch::Routing
   class Mapper
     # Adds the routes for a SOAP endpoint at +controller+.
     def wash_out(controller_name, options={})
-      options.each_with_index { |key, value|  @scope[key] = value } if @scope
+      if @scope
+        scope_frame = @scope.respond_to?(:frame) ? @scope.frame : @scope
+        options.each_with_index { |key, value|  scope_frame[key] = value }
+      end
+
       controller_class_name = [options[:module], controller_name].compact.join("/")
 
       match "#{controller_name}/wsdl"   => "#{controller_name}#_generate_wsdl", :via => :get, :format => false


### PR DESCRIPTION
I currently tried using this gem in a rails 5 application ( rails 5.0.0.rc1) 
and i  am currently using this routes:
```  
namespace :api do
    wash_out :project_service,  module: 'Api'
  end
```
which results in this error when trying to run the rails server with command ``` rails s ```

```ruby
/.rvm/gems/ruby-2.3.0@washout_builder_demo/bundler/gems/wash_out-ffa1bf83bed1/lib/wash_out.rb:24:
in `block in wash_out': undefined method `[]=' for 
<ActionDispatch::Routing::Mapper::Scope:0x00000003ce99d0> (NoMethodError)
```

I am currently using the latest commit from master from this repository. 

This fixes this issue and also preserves backward compatibility with older rails versions. 

Please let me know what you think. Thank you very much.  
