### PR TITLE
Revert "fix occurence in literal style wsdl"

### DIFF
--- a/app/helpers/wash_out_helper.rb
+++ b/app/helpers/wash_out_helper.rb
@@ -100,7 +100,6 @@ module WashOutHelper
   end
 
   def wsdl_occurence(param, inject, extend_with = {})
-    return extend_with if controller.soap_config.wsdl_style.to_s == 'document'
     data = {"#{'xsi:' if inject}nillable" => 'true'}
     if param.multiplied
       data["#{'xsi:' if inject}minOccurs"] = 0


### PR DESCRIPTION
Reverts inossidabile/wash_out#207

So, apparently the documentation I based my PR on was BS, and as such, my PR was BS!

The problem was the following message when importing the WSDL into SoapUI:

> WSDLException (at /definitions/message[4]/part): faultCode=INVALID_WSDL: Encountered illegal extension attribute 'minOccurs'. Extension attributes must be in a namespace other than WSDL's.

This was caused by the following action definition:

```ruby
soap_action 'listMessagesAfter',
            to: :list_messages_after,
            args: { last_id: :integer },
            return: { message_ids: [:integer] }
```

Which generates the following WSDL:

```xml
  <message name="listMessagesAfter_response">
    <part name="message_ids" type="xsd:int" minOccurs="0" xsd:maxOccurs="unbounded"/>
  </message>
```

In this context, `minOccurs`, `maxOccurs` etc are invalid. The CORRECT solution, however, is to wrap the response in its own type:

```ruby
soap_action 'listMessagesAfter',
            to: :list_messages_after,
            args: { last_id: :integer },
            return: { response: MessageListResponse }

# ... 

class MessageListResponse < WashOut::Type
  map message_ids: [:integer]
end
```

which will fix the error message.

Sorry for the inconvienience caused :disappointed: 