### PR TITLE
Handle arrays of empty elements properly

### DIFF
--- a/lib/wash_out/param.rb
+++ b/lib/wash_out/param.rb
@@ -61,6 +61,8 @@ module WashOut
           end
         end
       else
+        data = replace_empty_element_with_blank_string(data)
+
         operation = case type
           when 'string';       :to_s
           when 'integer';      :to_i
@@ -195,6 +197,18 @@ module WashOut
       end
 
       struct
+    end
+
+    def replace_empty_element_with_blank_string(data)
+      if data.is_a?(Hash) && hash_of_just_attributes?(data)
+        ""
+      else
+        data
+      end
+    end
+
+    def hash_of_just_attributes?(hash)
+      hash.keys.all? { |attribute| attribute.start_with?('@') }
     end
   end
 end

--- a/spec/lib/wash_out/param_spec.rb
+++ b/spec/lib/wash_out/param_spec.rb
@@ -37,10 +37,29 @@ describe WashOut::Param do
     end
   end
 
-  it "should accept nested empty arrays" do
-    soap_config = WashOut::SoapConfig.new({ camelize_wsdl: false })
-    map = WashOut::Param.parse_def(soap_config, {:nested => {:some_attr => :string, :empty => [:integer] }} )
-    expect(map[0].load( {:nested => nil}, :nested)).to eq({})
+  describe "arrays" do
+    it "should accept nested empty arrays" do
+      soap_config = WashOut::SoapConfig.new({ camelize_wsdl: false })
+      map = WashOut::Param.parse_def(soap_config, {:nested => {:some_attr => :string, :empty => [:integer] }} )
+      expect(map[0].load( {:nested => nil}, :nested)).to eq({})
+    end
+
+    it "should accept nested empty strings" do
+      soap_config = WashOut::SoapConfig.new({ camelize_wsdl: false })
+      map = WashOut::Param.parse_def(soap_config, {:list => [{name: :string}]} )
+
+      data = {
+        list: [
+          # Nori converts empty elements with attributes into a hash.
+          {name: {"@xsi:type" => "xsd:string"}},
+          {name: {"@xsi:type" => "xsd:string"}}
+        ]
+      }
+      expect(map[0].load(data, :list)).to eq([
+        {"name" => ""},
+        {"name" => ""},
+      ])
+    end
   end
 
   describe "booleans" do


### PR DESCRIPTION
It used to be that arrays containing empty string members returned their members as stringified hashes of the attributes instead of the empty string:

```xml
  <item>
    <foo xsi:type="xsd:string"></foo>
  </item>
  <item>
    <foo xsi:type="xsd:string"></foo>
  </item>
```

```ruby
  expect(list.first["foo"]).to eq("")
  # Is actually: '{"@xsi:type"=>"xsd:string"}`
```

This is a pretty conservative change as it only kicks in when:
1.  A parameter that shouldn't be a `struct` is a `Hash`.
2. All the keys in that hash are *attributes*.

That means that if the element was actually nested elements, it will still be returned as a stringified Hash.

---

I had a hard time making this understandable as this is an effect of how Nori is converting XML back and forth. Should I add the example XML to a comment to make it easier to understand, or is this enough?