### PR TITLE
Rails 5 API mode compatibility

### DIFF
--- a/lib/wash_out.rb
+++ b/lib/wash_out.rb
@@ -58,3 +58,11 @@ ActionController::Metal.class_eval do
     self.soap_config = options
   end
 end
+
+if Rails::VERSION::MAJOR >= 5
+  ActiveSupport.on_load :action_controller do
+    if self == ActionController::API
+      include ActionController::Helpers
+    end
+  end
+end

--- a/lib/wash_out.rb
+++ b/lib/wash_out.rb
@@ -60,6 +60,12 @@ ActionController::Metal.class_eval do
 end
 
 if Rails::VERSION::MAJOR >= 5
+  module ActionController
+    module ApiRendering
+      include ActionView::Rendering
+    end
+  end
+
   ActiveSupport.on_load :action_controller do
     if self == ActionController::API
       include ActionController::Helpers

--- a/lib/wash_out.rb
+++ b/lib/wash_out.rb
@@ -44,7 +44,7 @@ ActionController::Renderers.add :soap do |what, options|
   _render_soap(what, options)
 end
 
-ActionController::Base.class_eval do
+ActionController::Metal.class_eval do
 
   # Define a SOAP service. The function has no required +options+:
   # but allow any of :parser, :namespace, :wsdl_style, :snakecase_input,

--- a/lib/wash_out/dispatcher.rb
+++ b/lib/wash_out/dispatcher.rb
@@ -31,7 +31,7 @@ module WashOut
     end
 
     def _map_soap_parameters
-      @_params = _load_params action_spec[:in],
+      self.params = _load_params action_spec[:in],
         _strip_empty_nodes(action_spec[:in], xml_data)
     end
 

--- a/lib/wash_out/dispatcher.rb
+++ b/lib/wash_out/dispatcher.rb
@@ -170,7 +170,7 @@ module WashOut
       controller.send :helper, :wash_out
       controller.send :"before_#{entity}", :_authenticate_wsse,   :if => :soap_action?
       controller.send :"before_#{entity}", :_map_soap_parameters, :if => :soap_action?
-      controller.send :"skip_before_#{entity}", :verify_authenticity_token
+      controller.send :"skip_before_#{entity}", :verify_authenticity_token, :raise => false
     end
 
     def self.deep_select(collection, result=[], &blk)


### PR DESCRIPTION
With an API-only Rails app, `protect_from_forgery` may or may not be used. If not, the `:verify_authenticity_token` callback is never set. Starting in Rails 5, if `skip_before_action` is called for an unset callback an `ArgumentError` is raised. Adding `:raise => false` prevents the `ArgumentError` from being raised. See https://github.com/rails/rails/commit/d2876141d08341ec67cf6a11a073d1acfb920de7

Moving `soap_service` to `ActionController::Metal` makes the method available in all potential controller superclasses (`ActionController::Metal` is the superclass of both `ActionController::Base` and `ActionController::API`).

Include `ActionController::Helpers` module in `ActionController::API`. This is needed to use `helper` here: [lib/wash_out/dispatcher.rb#L170](https://github.com/inossidabile/wash_out/blob/0208891617955d88a69f9530fd0dfb261b4fb2a7/lib/wash_out/dispatcher.rb#L170)

Include `ActionView::Rendering` at the correct point in the ancestor hierarchy for the ability to render a response body from a template.

Closes #191 
