### PR TITLE
Preserve Rails 4 compatibility

### DIFF
--- a/lib/wash_out/dispatcher.rb
+++ b/lib/wash_out/dispatcher.rb
@@ -192,7 +192,12 @@ module WashOut
       controller.send :"before_#{entity}", :_authenticate_wsse,   :if => :soap_action?
       controller.send :"before_#{entity}", :_map_soap_parameters, :if => :soap_action?
       controller.send :"before_#{entity}", :_map_soap_headers, :if => :soap_action?
-      controller.send :"skip_before_#{entity}", :verify_authenticity_token, :raise => false
+
+      if defined?(Rails::VERSION::MAJOR) && (Rails::VERSION::MAJOR >= 5)
+        controller.send :"skip_before_#{entity}", :verify_authenticity_token, :raise => false
+      else
+        controller.send :"skip_before_#{entity}", :verify_authenticity_token
+      end
     end
 
     def self.deep_select(collection, result=[], &blk)

--- a/spec/dummy/app/controllers/application_controller.rb
+++ b/spec/dummy/app/controllers/application_controller.rb
@@ -1,3 +1,3 @@
 class ApplicationController < ActionController::Base
-  protect_from_forgery
+  protect_from_forgery with: :exception
 end

--- a/spec/lib/wash_out_spec.rb
+++ b/spec/lib/wash_out_spec.rb
@@ -184,16 +184,15 @@ describe WashOut do
         XML
       end
 
-      xit "succeeds when protect_from_forgery is enabled" do
+      it "succeeds when protect_from_forgery is enabled" do
 
-        # Enable allow_forgery_protection for this spec only
+        # Enable allow_forgery_protection (affects all subsequent specs)
+        # Alternatively, assign in spec/dummy/config/environments/test.rb
         Rails.application.config.after_initialize do
           ActionController::Base.allow_forgery_protection = true
         end
 
         mock_controller do
-          protect_from_forgery with: :exception
-
           soap_action "answer", :args => nil, :return => :int
           def answer
             render :soap => "42"

--- a/spec/lib/wash_out_spec.rb
+++ b/spec/lib/wash_out_spec.rb
@@ -2,6 +2,29 @@
 
 require 'spec_helper'
 
+SIMPLE_REQUEST_XML = <<-SIMPLE_REQUEST_XML_HEREDOC
+<?xml version="1.0" encoding="UTF-8"?>
+<env:Envelope xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tns="false" xmlns:env="http://schemas.xmlsoap.org/soap/envelope/">
+  <env:Body>
+    <tns:answer>
+      <value>42</value>
+    </tns:answer>
+  </env:Body>
+</env:Envelope>
+SIMPLE_REQUEST_XML_HEREDOC
+
+SIMPLE_RESPONSE_XML = <<-SIMPLE_RESPONSE_XML_HEREDOC
+<?xml version="1.0" encoding="UTF-8"?>
+<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tns="false">
+  <soap:Body>
+    <tns:answerResponse>
+      <Value xsi:type="xsd:int">42</Value>
+    </tns:answerResponse>
+  </soap:Body>
+</soap:Envelope>
+SIMPLE_RESPONSE_XML_HEREDOC
+
+
 describe WashOut do
 
   let :nori do
@@ -159,6 +182,26 @@ describe WashOut do
   </soap:Body>
 </soap:Envelope>
         XML
+      end
+
+      xit "succeeds when protect_from_forgery is enabled" do
+
+        # Enable allow_forgery_protection for this spec only
+        Rails.application.config.after_initialize do
+          ActionController::Base.allow_forgery_protection = true
+        end
+
+        mock_controller do
+          protect_from_forgery with: :exception
+
+          soap_action "answer", :args => nil, :return => :int
+          def answer
+            render :soap => "42"
+          end
+        end
+
+        expect(HTTPI.post("http://app/route/api/action", SIMPLE_REQUEST_XML).body).to eq SIMPLE_RESPONSE_XML
+
       end
 
       it "accept no parameters" do


### PR DESCRIPTION
When the application uses `protect_from_forgery with: :exception`, wash_out no longer works with Rails 4 (see https://github.com/qbwc/qbwc/issues/99), presumably due to [this tweak to support Rails 5](https://github.com/inossidabile/wash_out/commit/e5811b44f39320dece3cb1aa94d29478a7e0ed95).

This PR expands the test coverage to use `protect_from_forgery with: :exception`, and restores the original Rails 4 support.
