### PR TITLE
Support for rails config parameter 'relative_url_root'

### DIFF
--- a/lib/wash_out/router.rb
+++ b/lib/wash_out/router.rb
@@ -31,6 +31,9 @@ module WashOut
           routes.map{|x| x.format({})}                           # Rails 3.2
         end
 
+        if Rails.application.config.relative_url_root.present?
+          path.prepend Rails.application.config.relative_url_root
+        end
         return request.protocol + request.host_with_port + path.flatten.join('')
       end
     end

--- a/lib/wash_out/router.rb
+++ b/lib/wash_out/router.rb
@@ -14,7 +14,7 @@ module WashOut
 
         app = x.app
         app = app.app if app.respond_to?(:app)
-        if app.respond_to?(:routes)
+        if app.respond_to?(:routes) && app.routes.respond_to?(:routes)
           lookup_soap_routes(controller_name, app.routes.routes, path+[x], &block)
         end
       end


### PR DESCRIPTION
Fix URLs returned by `Router.url`, which are missing the subdirectory prefix (`config.relative_url_root`) when the current Rails application is mounted in a subdirectory. I haven't written a spec for this, do you think we should and if so, how should we proceed?

Also fixes an exception on `Router.lookup_soap_routes`, which raises `NoMethodError` exception when it encounters Sinatra routes (due to the fact that the Sinatra routes object does not respond to routes).

