### PR TITLE
Make dependency on action_view optional

### DIFF
--- a/lib/wash_out.rb
+++ b/lib/wash_out.rb
@@ -60,9 +60,11 @@ ActionController::Metal.class_eval do
 end
 
 if Rails::VERSION::MAJOR >= 5
-  module ActionController
-    module ApiRendering
-      include ActionView::Rendering
+  if defined?(ActionView::Rendering)
+    module ActionController
+      module ApiRendering
+        include ActionView::Rendering
+      end
     end
   end
 


### PR DESCRIPTION
From the discussion in #219.

wash_out is depending on action_view being available but does not list this dependency in the gemspec. This PR makes things work when action_view is not around.