### PR TITLE
Add custom name to SOAP definitions

### DIFF
--- a/lib/wash_out/dispatcher.rb
+++ b/lib/wash_out/dispatcher.rb
@@ -74,7 +74,7 @@ module WashOut
     def _generate_wsdl
       @map       = self.class.soap_actions
       @namespace = soap_config.namespace
-      @name      = controller_path
+      @name      = soap_config.name || controller_path
 
       render :template => "wash_out/#{soap_config.wsdl_style}/wsdl", :layout => false,
              :content_type => 'text/xml'

--- a/lib/wash_out/soap_config.rb
+++ b/lib/wash_out/soap_config.rb
@@ -6,6 +6,7 @@ module WashOut
     extend Forwardable
     DEFAULT_CONFIG = {
       parser: :rexml,
+      name: nil,
       namespace: 'urn:WashOut',
       wsdl_style: 'rpc',
       snakecase_input: false,

--- a/spec/lib/wash_out_spec.rb
+++ b/spec/lib/wash_out_spec.rb
@@ -91,6 +91,23 @@ describe WashOut do
       nori.parse wsdl
     end
 
+    it "has default name" do
+      name = xml[:definitions][:@name]
+      expect(name).to_not eq "washoutzin"
+    end
+
+    it "has a custom name" do
+      mock_controller(name: 'washoutzin') do
+        soap_action :result, :args => nil, :return => :int
+      end
+
+      custom_name_wsdl = HTTPI.get("http://app/route/api/wsdl").body
+      custom_name_xml = nori.parse custom_name_wsdl
+
+      name = custom_name_xml[:definitions][:@name]
+      expect(name).to eq "washoutzin"
+    end
+
     it "lists operations" do
       operations = xml[:definitions][:binding][:operation]
       expect(operations).to be_a_kind_of(Array)


### PR DESCRIPTION
Some clients can't read names with diagonals.

As we are using `wash_out 'soap/v1'` the default name was `name="soap/v1"` and also for `<portType name="soap/v1_port">`, with this change, you can override the name like this:

`soap_service name: 'soap_v1'`