### PR TITLE
Add SoapUI flavour to WSSE Digest

### DIFF
--- a/lib/wash_out/wsse.rb
+++ b/lib/wash_out/wsse.rb
@@ -92,6 +92,10 @@ module WashOut
       token = Base64.decode64(nonce) + timestamp.strftime("%Y-%m-%dT%H:%M:%SZ") + expected_password
       flavors << Base64.encode64(Digest::SHA1.digest(token)).chomp!
 
+      # SoapUI
+      token = Base64.decode64(nonce) + timestamp.strftime("%Y-%m-%dT%H:%M:%S.%3NZ") + expected_password
+      flavors << Base64.encode64(Digest::SHA1.digest(token)).chomp!
+
       flavors.each do |f|
         return true if f == password
       end


### PR DESCRIPTION
[SOAPUI](https://www.soapui.org/) sends the timestamp with three milliseconds.

Either we add this flavor or we don't parse the timestamp and read it raw as a string.

```ruby
#Java
[30] pry(SoapV1Controller)> token = Base64.decode64(nonce) + timestamp.strftime("%Y-%m-%dT%H:%M:%SZ") + expected_password
=> "g\xA8j%\xC6\xEDg]\xAC\x9B\v\xCB\xEE/\xAE\x982017-02-08T13:43:48Ztesting"
[31] pry(SoapV1Controller)> Base64.encode64(Digest::SHA1.digest(token)).chomp!
=> "tpPMnMVW3RqFk+NwvtnLVDS6k8s="
#SoapUI
[32] pry(SoapV1Controller)> token = Base64.decode64(nonce) + timestamp.strftime("%Y-%m-%dT%H:%M:%S.%3NZ") + expected_password
=> "g\xA8j%\xC6\xEDg]\xAC\x9B\v\xCB\xEE/\xAE\x982017-02-08T13:43:48.921Ztesting"
[33] pry(SoapV1Controller)> Base64.encode64(Digest::SHA1.digest(token)).chomp!
=> "ARVZsjT3cTLGtZw2Frum31UX1R4="
```

SoapUI Request:

```xml
POST http://localhost:3000/soap_v1/action HTTP/1.1
Accept-Encoding: gzip,deflate
Content-Type: text/xml;charset=UTF-8
SOAPAction: "Account"

<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/">
   <soapenv:Header><wsse:Security xmlns:wsse="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd" xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd"><wsse:UsernameToken wsu:Id="UsernameToken-5184D5FEA1E3559D9814865614289213"><wsse:Username>testing</wsse:Username><wsse:Password Type="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-username-token-profile-1.0#PasswordDigest">ARVZsjT3cTLGtZw2Frum31UX1R4=</wsse:Password><wsse:Nonce EncodingType="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-soap-message-security-1.0#Base64Binary">Z6hqJcbtZ12smwvL7i+umA==</wsse:Nonce><wsu:Created>2017-02-08T13:43:48.921Z</wsu:Created></wsse:UsernameToken></wsse:Security></soapenv:Header>
   <soapenv:Body/>
</soapenv:Envelope>
```