### PR TITLE
Booleans with the false value where marked as nil incorrectly

### DIFF
--- a/app/helpers/wash_out_helper.rb
+++ b/app/helpers/wash_out_helper.rb
@@ -3,7 +3,7 @@ module WashOutHelper
   def wsdl_data_options(param)
     case controller.soap_config.wsdl_style
     when 'rpc'
-      if param.map.present? || param.value
+      if param.map.present? || !param.value.nil?
         { :"xsi:type" => param.namespaced_type }
       else
         { :"xsi:nil" => true }


### PR DESCRIPTION
Before:
`<CanCheckBalance xsi:nil="true">false</CanCheckBalance>`

Now:
`<CanCheckBalance xsi:type="xsd:boolean">false</CanCheckBalance>`