### PR TITLE
Pass Apache CXF validation for document/literal

### DIFF
--- a/app/helpers/wash_out_helper.rb
+++ b/app/helpers/wash_out_helper.rb
@@ -64,6 +64,11 @@ module WashOutHelper
 
     if param.struct?
       if !defined.include?(param.basic_type)
+
+        if controller.soap_config.wsdl_style == 'document'
+          xml.tag! "element", :name => param.basic_type, :type => "tns:#{param.basic_type}"
+        end
+
         xml.tag! "xsd:complexType", :name => param.basic_type do
           attrs, elems = [], []
           param.map.each do |value|
@@ -106,5 +111,9 @@ module WashOutHelper
       data["#{'xsi:' if inject}maxOccurs"] = 'unbounded'
     end
     extend_with.merge(data)
+  end
+
+  def wsdl_occurence_part(param, inject, extend_with = {})
+    extend_with
   end
 end

--- a/app/helpers/wash_out_helper.rb
+++ b/app/helpers/wash_out_helper.rb
@@ -66,7 +66,7 @@ module WashOutHelper
       if !defined.include?(param.basic_type)
 
         if controller.soap_config.wsdl_style == 'document'
-          xml.tag! "element", :name => param.basic_type, :type => "tns:#{param.basic_type}"
+          xml.tag! "element", :name => param.element_type, :type => "tns:#{param.element_type}"
         end
 
         xml.tag! "xsd:complexType", :name => param.basic_type do

--- a/app/views/wash_out/document/wsdl.builder
+++ b/app/views/wash_out/document/wsdl.builder
@@ -22,12 +22,12 @@ xml.definitions 'xmlns' => 'http://schemas.xmlsoap.org/wsdl/',
   @map.each do |operation, formats|
     xml.message :name => "#{operation}" do
       formats[:in].each do |p|
-        xml.part wsdl_occurence(p, false, :name => p.name, :type => p.namespaced_type)
+        xml.part wsdl_occurence_part(p, false, :name => p.name, :element => p.namespaced_type)
       end
     end
     xml.message :name => formats[:response_tag] do
       formats[:out].each do |p|
-        xml.part wsdl_occurence(p, false, :name => p.name, :type => p.namespaced_type)
+        xml.part wsdl_occurence_part(p, false, :name => p.name, :element => p.namespaced_type)
       end
     end
   end
@@ -48,13 +48,11 @@ xml.definitions 'xmlns' => 'http://schemas.xmlsoap.org/wsdl/',
         xml.tag! "soap:operation", :soapAction => operation
         xml.input do
           xml.tag! "soap:body",
-            :use => "literal",
-            :namespace => @namespace
+            :use => "literal"
         end
         xml.output do
           xml.tag! "soap:body",
-            :use => "literal",
-            :namespace => @namespace
+            :use => "literal"
         end
       end
     end

--- a/app/views/wash_out/document/wsdl.builder
+++ b/app/views/wash_out/document/wsdl.builder
@@ -22,12 +22,12 @@ xml.definitions 'xmlns' => 'http://schemas.xmlsoap.org/wsdl/',
   @map.each do |operation, formats|
     xml.message :name => "#{operation}" do
       formats[:in].each do |p|
-        xml.part wsdl_occurence_part(p, false, :name => p.name, :element => p.namespaced_type)
+        xml.part wsdl_occurence_part(p, false, :name => p.name, :element => "tns:#{p.element_type}")
       end
     end
     xml.message :name => formats[:response_tag] do
       formats[:out].each do |p|
-        xml.part wsdl_occurence_part(p, false, :name => p.name, :element => p.namespaced_type)
+        xml.part wsdl_occurence_part(p, false, :name => p.name, :element => "tns:#{p.element_type}")
       end
     end
   end

--- a/lib/wash_out/dispatcher.rb
+++ b/lib/wash_out/dispatcher.rb
@@ -137,12 +137,14 @@ module WashOut
         header = HashWithIndifferentAccess.new(header)
       end
 
+      result = inject.call(result, @action_spec[:out])
+
       render :template => "wash_out/#{soap_config.wsdl_style}/response",
              :layout => false,
              :locals => {
                :header => header.present? ? inject.call(header, @action_spec[:header_out])
                                       : nil,
-               :result => inject.call(result, @action_spec[:out])
+               :result => soap_config.wsdl_style == "rpc" ? result : result.first.map
              },
              :content_type => 'text/xml'
     end

--- a/lib/wash_out/param.rb
+++ b/lib/wash_out/param.rb
@@ -105,6 +105,10 @@ module WashOut
       return source_class.wash_out_param_name(@soap_config)
     end
 
+    def element_type
+      return basic_type.split(".").last
+    end
+
     def xsd_type
       return 'int' if type.to_s == 'integer'
       return 'dateTime' if type.to_s == 'datetime'


### PR DESCRIPTION
Hi,

Currently I'm using wash_out in a project where I need to publish the rpc/encoded version of the WSDL for one client and the document/literal version for another client, due that they use different soap app clients.

rpc/encoded works as is, using TIBCO client.
document/literal does not work, using Apache CXF client.

Both implementations worked fine in Savon because it is not that strict with the validation.

Some of the errors that where displayed in Apache CXF:

```
WSDLValidator Error : WSI-BP-1.0 R2716 violation: Operation 'Account' soapBody MUST NOT have namespace attribute
```

```
A document-literal binding in a DESCRIPTION MUST refer, in each of its soapbind:body element(s),only to wsdl:part element(s) that have been defined using the element attribute.
```

First things first, in order to be a valid document/literal, you need to ONLY manage a single part per message, it does not allow multipart messages like rpc/encoded, so, all your operations should send and return a single object, this is correct:

```
    soap_action :bills,
      args: {
        bills: Soap::Bills
      },
      return: {
        bills_response: Soap::BillsResponse
      }
```

where this is incorrect (for document/literal):

```
    soap_action :bills,
      args: {
        bills: Soap::Bills
      },
      return: {
        pagination: Soap::Pagination,
        bills: Soap::Bills
      }
```

So, you only need to wrap your multipart message in a single part to force this, easy.

The problem is that current implementation of wash_out returns the message "doubled" due the wrapper (where first `bills_response` is the `message` and second one is the wrapper `object` itself):

```
{:bills_response=>{:bills_response=>{:bills=>{...}, :pagination=>{...}}}
```

And app clients are expecting this:

```
{:bills_response=>{:bills=>{...}, :pagination=>{...}}
```

So, for document/literal *I removed from the WSDL the first external wrapper found*.

----

Another complain of the validator is that `nillable` should not be in `parts`.

----

Another complain of the validator is that `namespace` should not be in `operations`.

----

Another complain of the validator is that you can not use `type` in `parts`, instead you should use `element`

----

Another complain is that every `complexType` need to define a corresponding `element` with the same `name` and defining the `type`.

----

Now the results of the validation:

```
$ ./wsdlvalidator http://localhost:3000/soap_v1/wsdl
Passed Validation : Valid WSDL
```

Hope this makes sense.