### PR TITLE
[Rails 5.1.0 Compatibility BugFix] Inserting middleware when catch_xml_errors is set to true

### DIFF
--- a/lib/wash_out/engine.rb
+++ b/lib/wash_out/engine.rb
@@ -1,10 +1,9 @@
-
 module WashOut
   class Engine < ::Rails::Engine
     config.wash_out = ActiveSupport::OrderedOptions.new
     initializer "wash_out.configuration" do |app|
       if app.config.wash_out[:catch_xml_errors]
-        app.config.middleware.insert_after 'ActionDispatch::ShowExceptions', WashOut::Middleware
+        app.config.middleware.insert_after(ActionDispatch::ShowExceptions, WashOut::Middleware)
       end
     end
 


### PR DESCRIPTION
Hello,
  I was trying today to upgrade one of my projects to rails 5.1.0 , which depends to this gem and was failing with error: "No such middleware to insert after: "ActionDispatch::ShowExceptions",

The issue was that here: https://github.com/rails/rails/blob/master/actionpack/lib/action_dispatch/middleware/stack.rb#L104 , the check is done now on the class itself directly when rails tries to find the index of the middleware "ActionDispatch::ShowExceptions" 

So strings are not working anymore when passing middlewares to insert_after in the stack, putting directly the class name instead works perfectly.

I tested this with other rails versions and seems to work fine also. Please let me know what you think.

Thank you very much. 
