### PR TITLE
Don't crash when param_options are nil instead of hash

### DIFF
--- a/app/helpers/wash_out_helper.rb
+++ b/app/helpers/wash_out_helper.rb
@@ -29,7 +29,7 @@ module WashOutHelper
 
       tag_name = param.name
       param_options = wsdl_data_options(param)
-      param_options.merge! wsdl_data_attrs(param) unless param_options.nil?
+      param_options.merge! wsdl_data_attrs(param) if param_options.is_a?(Hash)
 
       if param.struct?
         if param.multiplied
@@ -39,7 +39,8 @@ module WashOutHelper
               blk = proc { wsdl_data(xml, p.map) }
             end
             attrs.reject! { |_, v| v.nil? }
-            xml.tag! tag_name, param_options.merge(attrs), &blk
+            options_and_attrs = param_options.is_a?(Hash) ? param_options.merge(attrs) : attrs
+            xml.tag! tag_name, options_and_attrs, &blk
           end
         else
           xml.tag! tag_name, param_options do

--- a/app/helpers/wash_out_helper.rb
+++ b/app/helpers/wash_out_helper.rb
@@ -29,7 +29,7 @@ module WashOutHelper
 
       tag_name = param.name
       param_options = wsdl_data_options(param)
-      param_options.merge! wsdl_data_attrs(param) if param_options.is_a?(Hash)
+      param_options.merge! wsdl_data_attrs(param) unless param_options.nil?
 
       if param.struct?
         if param.multiplied

--- a/app/helpers/wash_out_helper.rb
+++ b/app/helpers/wash_out_helper.rb
@@ -29,7 +29,7 @@ module WashOutHelper
 
       tag_name = param.name
       param_options = wsdl_data_options(param)
-      param_options.merge! wsdl_data_attrs(param)
+      param_options.merge! wsdl_data_attrs(param) if param_options.is_a?(Hash)
 
       if param.struct?
         if param.multiplied

--- a/app/helpers/wash_out_helper.rb
+++ b/app/helpers/wash_out_helper.rb
@@ -9,7 +9,9 @@ module WashOutHelper
         { :"xsi:nil" => true }
       end
     when 'document'
-      { }
+      {}
+    else
+      {}
     end
   end
 
@@ -29,7 +31,7 @@ module WashOutHelper
 
       tag_name = param.name
       param_options = wsdl_data_options(param)
-      param_options.merge! wsdl_data_attrs(param) if param_options.is_a?(Hash)
+      param_options.merge! wsdl_data_attrs(param)
 
       if param.struct?
         if param.multiplied
@@ -39,8 +41,7 @@ module WashOutHelper
               blk = proc { wsdl_data(xml, p.map) }
             end
             attrs.reject! { |_, v| v.nil? }
-            options_and_attrs = param_options.is_a?(Hash) ? param_options.merge(attrs) : attrs
-            xml.tag! tag_name, options_and_attrs, &blk
+            xml.tag! tag_name, param_options.merge(attrs), &blk
           end
         else
           xml.tag! tag_name, param_options do


### PR DESCRIPTION
For some reason that line ends up being nil and I crash locally when requesting anything to my endpoint.