### PR TITLE
Option to change the service name

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,7 @@ Available properties are:
 * **namespace**: SOAP namespace to use. Default is `urn:WashOut`.
 * **snakecase_input**: Determines if WashOut should modify parameters keys to snakecase. Default is `false`.
 * **camelize_wsdl**: Determines if WashOut should camelize types within WSDL and responses. Supports `true` for CamelCase and `:lower` for camelCase. Default is `false`.
+* **service_name**: Allows to define a custom name for the SOAP service. By default, the name is set as `service`.
 
 ### Camelization
 

--- a/app/views/wash_out/document/wsdl.builder
+++ b/app/views/wash_out/document/wsdl.builder
@@ -60,7 +60,7 @@ xml.definitions 'xmlns' => 'http://schemas.xmlsoap.org/wsdl/',
     end
   end
 
-  xml.service :name => "service" do
+  xml.service :name => @service_name do
     xml.port :name => "#{@name}_port", :binding => "tns:#{@name}_binding" do
       xml.tag! "soap:address", :location => WashOut::Router.url(request, @name)
     end

--- a/app/views/wash_out/rpc/wsdl.builder
+++ b/app/views/wash_out/rpc/wsdl.builder
@@ -60,7 +60,7 @@ xml.definitions 'xmlns' => 'http://schemas.xmlsoap.org/wsdl/',
     end
   end
 
-  xml.service :name => "service" do
+  xml.service :name => @service_name do
     xml.port :name => "#{@name}_port", :binding => "tns:#{@name}_binding" do
       xml.tag! "soap:address", :location => WashOut::Router.url(request, @name)
     end

--- a/lib/wash_out/dispatcher.rb
+++ b/lib/wash_out/dispatcher.rb
@@ -72,9 +72,10 @@ module WashOut
 
     # This action generates the WSDL for defined SOAP methods.
     def _generate_wsdl
-      @map       = self.class.soap_actions
-      @namespace = soap_config.namespace
-      @name      = controller_path
+      @map          = self.class.soap_actions
+      @namespace    = soap_config.namespace
+      @name         = controller_path
+      @service_name = soap_config.service_name
 
       render :template => "wash_out/#{soap_config.wsdl_style}/wsdl", :layout => false,
              :content_type => 'text/xml'

--- a/lib/wash_out/soap_config.rb
+++ b/lib/wash_out/soap_config.rb
@@ -15,6 +15,7 @@ module WashOut
       wsse_password: nil,
       wsse_auth_callback: nil,
       soap_action_routing: true,
+      service_name: 'service'
     }
 
     attr_reader :config

--- a/spec/lib/wash_out_spec.rb
+++ b/spec/lib/wash_out_spec.rb
@@ -119,6 +119,40 @@ describe WashOut do
     end
   end
 
+  describe 'WSDL' do
+    let :wsdl do
+      mock_controller
+
+      HTTPI.get('http://app/route/api/wsdl').body
+    end
+
+    let :xml do
+      nori.parse wsdl
+    end
+
+    it "defines a default service name as 'service'" do
+      service_name = xml[:definitions][:service][:@name]
+      expect(service_name).to match 'service'
+    end
+  end
+
+  describe 'WSDL' do
+    let :wsdl do
+      mock_controller service_name: 'CustomServiceName'
+
+      HTTPI.get('http://app/route/api/wsdl').body
+    end
+
+    let :xml do
+      nori.parse wsdl
+    end
+
+    it 'allows to define a custom service name' do
+      service_name = xml[:definitions][:service][:@name]
+      expect(service_name).to match 'CustomServiceName'
+    end
+  end
+
   describe "Dispatcher" do
 
     context "simple actions" do


### PR DESCRIPTION
This PR resolves https://github.com/inossidabile/wash_out/issues/242 by adding a `service_name` configuration option, which allows to define a custom SOAP service name.