### PR TITLE
add ruby-2.4.2 to travis for rails-5.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,12 @@ gemfile:
   - gemfiles/rails_5.0.0.gemfile
   - gemfiles/rails_5.1.1.gemfile
 rvm:
-  - 2.3.0
+  - 2.3.5
 before_install:
   - gem update bundler
+matrix:
+  include:
+    - rvm: 2.4.2
+      gemfile: gemfiles/rails_5.0.0.gemfile
+    - rvm: 2.4.2
+      gemfile: gemfiles/rails_5.1.1.gemfile

--- a/spec/dummy/config/application.rb
+++ b/spec/dummy/config/application.rb
@@ -12,7 +12,6 @@ if Rails::VERSION::MAJOR >= 4
   end
 end
 
-Bundler.require
 require "wash_out"
 
 module Dummy

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,6 +2,7 @@
 ENV["RAILS_ENV"] = "test"
 
 require "simplecov"
+require 'simplecov-summary'
 SimpleCov.start do
   add_filter 'spec'
   add_group 'Library', 'lib'


### PR DESCRIPTION
This adds ruby-2.4.2 to travis and updates to 2.3.5.  Out of the box rspec segfaulted until I modified spec/dummy/config/application.rb, but that change didn't seem to affect anything on either ruby version.