### PR TITLE
Added the functionality of WSDL action attributes optional to nillable = true

### DIFF
--- a/app/helpers/wash_out_helper.rb
+++ b/app/helpers/wash_out_helper.rb
@@ -3,15 +3,13 @@ module WashOutHelper
   def wsdl_data_options(param)
     case controller.soap_config.wsdl_style
     when 'rpc'
-      if param.map.present? || !param.value.nil?
+      if param.map.present? || param.value
         { :"xsi:type" => param.namespaced_type }
       else
         { :"xsi:nil" => true }
       end
     when 'document'
-      {}
-    else
-      {}
+      { }
     end
   end
 
@@ -24,46 +22,9 @@ module WashOutHelper
       end
     end
   end
-
-  def wsdl_data(xml, params)
-    params.each do |param|
-      next if param.attribute?
-
-      tag_name = param.name
-      param_options = wsdl_data_options(param)
-      param_options.merge! wsdl_data_attrs(param)
-
-      if param.struct?
-        if param.multiplied
-          param.map.each do |p|
-            attrs = wsdl_data_attrs p
-            if p.is_a?(Array) || p.map.size > attrs.size
-              blk = proc { wsdl_data(xml, p.map) }
-            end
-            attrs.reject! { |_, v| v.nil? }
-            xml.tag! tag_name, param_options.merge(attrs), &blk
-          end
-        else
-          xml.tag! tag_name, param_options do
-            wsdl_data(xml, param.map)
-          end
-        end
-      else
-        if param.multiplied
-          param.value = [] unless param.value.is_a?(Array)
-          param.value.each do |v|
-            xml.tag! tag_name, v, param_options
-          end
-        else
-          xml.tag! tag_name, param.value, param_options
-        end
-      end
-    end
-  end
-
+  
   def wsdl_type(xml, param, defined=[])
     more = []
-
     if param.struct?
       if !defined.include?(param.basic_type)
         xml.tag! "xsd:complexType", :name => param.basic_type do
@@ -75,8 +36,7 @@ module WashOutHelper
             else
               elems << value
             end
-          end
-
+          end 
           if elems.any?
             xml.tag! "xsd:sequence" do
               elems.each do |value|
@@ -101,12 +61,68 @@ module WashOutHelper
     end
   end
 
-  def wsdl_occurence(param, inject, extend_with = {})
-    data = {"#{'xsi:' if inject}nillable" => 'true'}
-    if param.multiplied
-      data["#{'xsi:' if inject}minOccurs"] = 0
-      data["#{'xsi:' if inject}maxOccurs"] = 'unbounded'
+   def wsdl_occurence(param, inject, extend_with = {})
+    if (param.multiplied && param.optional)
+       data = {
+        "#{'xsi:' if inject}minOccurs" => 0,
+        "#{'xsi:' if inject}maxOccurs" => 'unbounded',
+        "#{'xsi:' if inject}nillable" => 'true'
+      }
+
+    elsif param.multiplied
+      data = {
+        "#{'xsi:' if inject}minOccurs" => 0,
+        "#{'xsi:' if inject}maxOccurs" => 'unbounded'
+      }
+    elsif param.optional
+      data = {"#{'xsi:' if inject}nillable" => 'true'}
+      # data = {
+      #   "#{'xsi:' if inject}minOccurs" => 0,
+      # }
+    else
+      data = {}
     end
+
     extend_with.merge(data)
+  end
+
+  def wsdl_data(xml, params)
+    Rails.logger.debug params 
+    params.each do |param|
+      tag_name = param.name
+
+      if !param.struct?
+        if param.multiplied
+          param.value = [] unless param.value.is_a?(Array)
+          param.value.each do |v|
+            xml.tag! tag_name, v, "xsi:type" => param.namespaced_type
+          end
+        elsif param.optional
+          if !param.value.nil?
+            xml.tag! tag_name, param.value, "xsi:type" => param.namespaced_type
+          end
+        else
+          xml.tag! tag_name, param.value, "xsi:type" => param.namespaced_type
+        end
+      else
+        if param.multiplied
+          param.map.each do |p|
+            xml.tag! tag_name, "xsi:type" => param.namespaced_type do
+              wsdl_data(xml, p.map)
+            end
+          end
+        elsif param.optional
+          if !param.map.empty?
+              xml.tag! tag_name, "xsi:type" => param.namespaced_type do
+                wsdl_data(xml, param.map)
+              end
+          end
+        else
+          xml.tag! tag_name, "xsi:type" => param.namespaced_type do
+            wsdl_data(xml, param.map)
+          end
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
This is the functionality and fixed of document style where nillable=true is generated so to avoid this I have added a functionality where we can make any attributes as nillable = true. Currently WSDL is not valid due to nillable =true on parent tag as well on WSDL.